### PR TITLE
Optionフォーム統合（nested form）

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -12,6 +12,7 @@ class DecisionsController < ApplicationController
 
   def new
     @decision = Decision.new
+    3.times { @decision.options.build }
   end
 
   def create
@@ -26,6 +27,7 @@ class DecisionsController < ApplicationController
 
   def edit
     @decision = current_user.decisions.find(params[:id])
+    @decision.options.build if @decision.options.empty?
   end
 
   def update
@@ -48,6 +50,10 @@ class DecisionsController < ApplicationController
   private
 
   def decision_params
-    params.require(:decision).permit(:title, :category_id)
+    params.require(:decision).permit(
+      :title,
+      :category_id,
+      options_attributes: [:id, :content, :_destroy]
+      )
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -2,6 +2,7 @@ class Decision < ApplicationRecord
   belongs_to :user
   belongs_to :category, optional: true
   has_many :options, dependent: :destroy
+  accepts_nested_attributes_for :options, allow_destroy: true
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :category_id, presence: true

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -11,7 +11,7 @@
   </div>
 <% end %>
 
-<%= form_with model: @decision do |f| %>
+<%= form_with model: @decision, local: true do |f| %>
   <div>
     <%= f.label :title, "タイトル" %><br>
     <%= f.text_field :title %>
@@ -21,6 +21,18 @@
     <%= f.label :category_id, "カテゴリ" %><br>
     <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "選択してください" %>
   </div>
+
+  <hr>
+
+  <h3>選択肢</h3>
+
+  <%= f.fields_for :options do |option_form| %>
+    <div>
+      <%= option_form.text_field :content %>
+      <%= option_form.check_box :_destroy %>
+      <%= option_form.label :_destroy, "削除" %>
+    </div>
+  <% end %>
 
   <div>
     <%= f.submit "更新する" %>

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -11,7 +11,7 @@
   </div>
 <% end %>
 
-<%= form_with model: @decision do |f| %>
+<%= form_with model: @decision, local: true do |f| %>
   <div>
     <%= f.label :title, "タイトル" %><br>
     <%= f.text_field :title %>
@@ -21,6 +21,14 @@
     <%= f.label :category_id, "カテゴリ" %><br>
     <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "選択してください" %>
   </div>
+
+  <hr>
+
+   <%= f.fields_for :options do |option_form| %>
+    <div>
+      <%= option_form.text_field :content %>
+    </div>
+  <% end %>
 
   <div>
     <%= f.submit "作成する" %>


### PR DESCRIPTION
## 概要
Decision編集画面でOption（選択肢）を同時に編集・削除できるように対応

## 変更内容
- Decisionモデルにaccepts_nested_attributes_forを追加
- strong parametersにoptions_attributesを追加
- editアクションでOptionの初期化処理を追加
- 編集画面にfields_forを使ったOption編集フォームを実装
- Option削除用のチェックボックスを追加

## 確認方法
- Decision編集画面にアクセス
- Optionの内容を編集して更新できることを確認
- 削除チェックを入れてOptionが削除されることを確認

## 関連Issue
Closes #42 