### PR TITLE
EmotionTypeモデル作成

### DIFF
--- a/app/models/emotion_type.rb
+++ b/app/models/emotion_type.rb
@@ -1,0 +1,3 @@
+class EmotionType < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20260409134217_create_emotion_types.rb
+++ b/db/migrate/20260409134217_create_emotion_types.rb
@@ -1,0 +1,9 @@
+class CreateEmotionTypes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :emotion_types do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_05_124923) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_134217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,6 +29,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_05_124923) do
     t.bigint "user_id", null: false
     t.index ["category_id"], name: "index_decisions_on_category_id"
     t.index ["user_id"], name: "index_decisions_on_user_id"
+  end
+
+  create_table "emotion_types", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.datetime "updated_at", null: false
   end
 
   create_table "options", force: :cascade do |t|

--- a/test/fixtures/emotion_types.yml
+++ b/test/fixtures/emotion_types.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/emotion_type_test.rb
+++ b/test/models/emotion_type_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EmotionTypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
EmotionTypeモデルを作成

## 変更内容
- EmotionTypeモデルを新規作成
- nameカラムを追加
- マイグレーションを実行

## 確認方法
- rails db:migrate が成功することを確認
- schema.rb にemotion_typesテーブルが追加されていることを確認

## 関連Issue
Closes #43 

