### PR TITLE
DecisionEmotionモデル作成

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -1,6 +1,8 @@
 class Decision < ApplicationRecord
   belongs_to :user
   belongs_to :category, optional: true
+  has_many :decision_emotions, dependent: :destroy
+  has_many :emotion_types, through: :decision_emotions
   has_many :options, dependent: :destroy
   accepts_nested_attributes_for :options, allow_destroy: true
 

--- a/app/models/decision_emotion.rb
+++ b/app/models/decision_emotion.rb
@@ -1,0 +1,4 @@
+class DecisionEmotion < ApplicationRecord
+  belongs_to :decision
+  belongs_to :emotion_type
+end

--- a/app/models/emotion_type.rb
+++ b/app/models/emotion_type.rb
@@ -1,3 +1,5 @@
 class EmotionType < ApplicationRecord
+  has_many :decision_emotions, dependent: :destroy
+  has_many :decisions, through: :decision_emotions
   validates :name, presence: true, uniqueness: true
 end

--- a/db/migrate/20260409140247_create_decision_emotions.rb
+++ b/db/migrate/20260409140247_create_decision_emotions.rb
@@ -1,0 +1,10 @@
+class CreateDecisionEmotions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :decision_emotions do |t|
+      t.references :decision, null: false, foreign_key: true
+      t.references :emotion_type, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_134217) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_140247) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,6 +18,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_134217) do
     t.datetime "created_at", null: false
     t.string "name"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "decision_emotions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "decision_id", null: false
+    t.bigint "emotion_type_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decision_id"], name: "index_decision_emotions_on_decision_id"
+    t.index ["emotion_type_id"], name: "index_decision_emotions_on_emotion_type_id"
   end
 
   create_table "decisions", force: :cascade do |t|
@@ -63,6 +72,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_134217) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "decision_emotions", "decisions"
+  add_foreign_key "decision_emotions", "emotion_types"
   add_foreign_key "decisions", "categories"
   add_foreign_key "decisions", "users"
   add_foreign_key "options", "decisions"

--- a/test/fixtures/decision_emotions.yml
+++ b/test/fixtures/decision_emotions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  decision: one
+  emotion_type: one
+
+two:
+  decision: two
+  emotion_type: two

--- a/test/models/decision_emotion_test.rb
+++ b/test/models/decision_emotion_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DecisionEmotionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
DecisionとEmotionTypeを紐づけるDecisionEmotionモデルを作成

## 変更内容
- DecisionEmotionモデルを新規作成
- decision_id / emotion_type_id の外部キーを追加
- DecisionとEmotionTypeの多対多関連を設定（has_many :through）
- マイグレーションを実行

## 確認方法
- rails db:migrate が成功することを確認
- schema.rb にdecision_emotionsテーブルが追加されていることを確認
- モデルで関連が定義されていることを確認

## 関連Issue
Closes #44 