### PR TITLE
感情選択機能作成

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -53,7 +53,8 @@ class DecisionsController < ApplicationController
     params.require(:decision).permit(
       :title,
       :category_id,
-      options_attributes: [:id, :content, :_destroy]
+      options_attributes: [:id, :content, :_destroy],
+      emotion_type_ids: []
       )
   end
 end

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -34,6 +34,17 @@
     </div>
   <% end %>
 
+  <hr>
+
+  <h3>感情</h3>
+
+  <% EmotionType.all.each do |emotion| %>
+    <div>
+      <%= check_box_tag "decision[emotion_type_ids][]", emotion.id, @decision.emotion_type_ids.include?(emotion.id) %>
+      <%= emotion.name %>
+    </div>
+  <% end %>
+
   <div>
     <%= f.submit "更新する" %>
   </div>

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -24,9 +24,22 @@
 
   <hr>
 
-   <%= f.fields_for :options do |option_form| %>
+  <h3>選択肢</h3>
+
+  <%= f.fields_for :options do |option_form| %>
     <div>
       <%= option_form.text_field :content %>
+    </div>
+  <% end %>
+
+  <hr>
+
+  <h3>感情</h3>
+
+  <% EmotionType.all.each do |emotion| %>
+    <div>
+      <%= check_box_tag "decision[emotion_type_ids][]", emotion.id, @decision.emotion_type_ids.include?(emotion.id) %>
+      <%= emotion.name %>
     </div>
   <% end %>
 

--- a/app/views/decisions/show.html.erb
+++ b/app/views/decisions/show.html.erb
@@ -6,6 +6,16 @@
 
 <hr>
 
+<h3>感情</h3>
+
+<ul>
+  <% @decision.emotion_types.each do |emotion| %>
+    <li><%= emotion.name %></li>
+  <% end %>
+</ul>
+
+<hr>
+
 <h3>選択肢</h3>
 
 <ul>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,8 @@
 Category.create(name: "仕事")
 Category.create(name: "恋愛")
 Category.create(name: "お金")
+EmotionType.create!(name: "嬉しい")
+EmotionType.create!(name: "不安")
+EmotionType.create!(name: "後悔")
+EmotionType.create!(name: "ワクワク")
+EmotionType.create!(name: "安心")


### PR DESCRIPTION
## 概要
Decisionに感情（EmotionType）を紐づけて選択・保存・表示できる機能を実装

## 変更内容
- DecisionとEmotionTypeの多対多関連を利用して感情を紐づけ
- strong parametersにemotion_type_idsを追加
- new/edit画面に感情選択（チェックボックス）を追加
- show画面に選択した感情の表示を追加
- seedデータでEmotionTypeを登録

## 確認方法
- rails db:seed を実行して感情データを登録
- Decision作成画面で感情を選択して保存できることを確認
- 編集画面で感情の追加・解除ができることを確認
- 詳細画面に選択した感情が表示されることを確認

## 関連Issue
Closes #45 