### PR TITLE
Optionバリデーション強化

### DIFF
--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,5 +1,6 @@
 class Option < ApplicationRecord
   belongs_to :decision
 
-  validates :content, presence: true
+  validates :content, presence: true, length: { maximum: 100 }
+  validates :content, uniqueness: { scope: :decision_id }
 end

--- a/db/migrate/20260421124055_add_index_to_options_content.rb
+++ b/db/migrate/20260421124055_add_index_to_options_content.rb
@@ -1,0 +1,5 @@
+class AddIndexToOptionsContent < ActiveRecord::Migration[8.1]
+  def change
+    add_index :options, [:decision_id, :content], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_140247) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_124055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_140247) do
     t.datetime "created_at", null: false
     t.bigint "decision_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["decision_id", "content"], name: "index_options_on_decision_id_and_content", unique: true
     t.index ["decision_id"], name: "index_options_on_decision_id"
   end
 


### PR DESCRIPTION
## 概要
Optionモデルにバリデーションを追加し、データの整合性を強化しました。

## 変更内容
- contentに対する必須バリデーションを追加
- contentの最大文字数を100文字に制限
- decision単位でのcontentの一意性バリデーションを追加
- DBレベルでの一意制約（decision_id + content）を追加

## 目的
- 同一Decision内で重複した選択肢が登録されるのを防ぐため
- 不正データやUI崩れを防ぐため
- モデルとDBの両方でデータ整合性を担保するため

## 確認方法
- 同じDecision内で同じcontentを登録するとエラーになること
- 別Decisionでは同じcontentが登録できること
- 101文字以上のcontentが登録できないこと
- contentが空の場合に登録できないこと

## 関連Issue
Closes #89 