### PR TITLE
selected_option_idカラム追加

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -1,6 +1,7 @@
 class Decision < ApplicationRecord
   belongs_to :user
   belongs_to :category, optional: true
+  belongs_to :selected_option, class_name: 'Option', optional: true
   has_many :decision_emotions, dependent: :destroy
   has_many :emotion_types, through: :decision_emotions
   has_many :options, dependent: :destroy

--- a/db/migrate/20260422144207_add_selected_option_to_decisions.rb
+++ b/db/migrate/20260422144207_add_selected_option_to_decisions.rb
@@ -1,0 +1,5 @@
+class AddSelectedOptionToDecisions < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :decisions, :selected_option, foreign_key: { to_table: :options }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_124055) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_144207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -33,10 +33,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_124055) do
     t.bigint "category_id"
     t.datetime "created_at", null: false
     t.text "description"
+    t.bigint "selected_option_id"
     t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["category_id"], name: "index_decisions_on_category_id"
+    t.index ["selected_option_id"], name: "index_decisions_on_selected_option_id"
     t.index ["user_id"], name: "index_decisions_on_user_id"
   end
 
@@ -76,6 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_124055) do
   add_foreign_key "decision_emotions", "decisions"
   add_foreign_key "decision_emotions", "emotion_types"
   add_foreign_key "decisions", "categories"
+  add_foreign_key "decisions", "options", column: "selected_option_id"
   add_foreign_key "decisions", "users"
   add_foreign_key "options", "decisions"
 end


### PR DESCRIPTION
## 概要
Decisionに最終決断（selected_option）を紐づけるためのカラムと関連を追加しました。

## 変更内容
- decisionsテーブルにselected_option_idカラムを追加
- optionsテーブルへの外部キー制約を追加
- Decisionモデルにselected_option（belongs_to）を追加

## 目的
- 複数の選択肢の中から1つを選ぶ機能を実現するため
- アプリのコア機能（意思決定）を成立させるため

## 確認方法
- Decisionに対してOptionをselected_optionとして設定できること
- selected_option_idに対して外部キー制約が効いていること
- 不正なOption IDが保存されないこと

## 関連Issue
Closes #90 
Closes #91 