### PR TITLE
selected_option整合性バリデーション

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -2,11 +2,40 @@ class Decision < ApplicationRecord
   belongs_to :user
   belongs_to :category, optional: true
   belongs_to :selected_option, class_name: 'Option', optional: true
+
   has_many :decision_emotions, dependent: :destroy
   has_many :emotion_types, through: :decision_emotions
   has_many :options, dependent: :destroy
-  accepts_nested_attributes_for :options, allow_destroy: true
+
+  accepts_nested_attributes_for :options,
+    allow_destroy: true,
+    reject_if: :all_blank
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :category_id, presence: true
+
+  validate :selected_option_must_belong_to_decision
+  validate :options_content_uniqueness
+
+  private
+
+  def selected_option_must_belong_to_decision
+    return if selected_option_id.blank?
+
+    unless options.where(id: selected_option_id).exists?
+      errors.add(:selected_option, "はこの決断に属する選択肢から選んでください")
+    end
+  end
+
+  def options_content_uniqueness
+    contents = options.map(&:content).reject(&:blank?)
+
+    duplicates = contents.group_by(&:itself)
+                         .select { |_, v| v.size > 1 }
+                         .keys
+
+    duplicates.each do |dup|
+      errors.add(:base, "選択肢「#{dup}」が重複しています")
+    end
+  end
 end


### PR DESCRIPTION
## 概要
Decisionにおけるselected_optionの整合性バリデーションと、Optionの重複防止バリデーションを追加

## 変更内容
- selected_optionが該当Decisionに属するOptionのみ選択可能に制御
- Optionのcontent重複チェックを追加（同一Decision内）
- 空のOptionを保存しないように設定（reject_if: :all_blank）

## 確認方法
- 別DecisionのOptionをselected_optionに設定 → 保存されないこと
- 同じcontentのOptionを複数入力 → エラーが表示されること
- 正常なOption選択 → 保存されること

## 関連Issue
Closes #87 