### PR TITLE
最終決断の保存ロジックおよびUIを実装

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -53,8 +53,9 @@ class DecisionsController < ApplicationController
     params.require(:decision).permit(
       :title,
       :category_id,
+      :selected_option_id,
       options_attributes: [:id, :content, :_destroy],
       emotion_type_ids: []
-      )
+    )
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,21 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+document.addEventListener("turbo:load", () => {
+  const inputs = document.querySelectorAll(".option-input");
+
+  inputs.forEach((input) => {
+    input.addEventListener("input", (e) => {
+      const index = e.target.dataset.index;
+      const label = document.getElementById(`option-label-${index}`);
+
+      if (label) {
+        label.textContent = e.target.value || `選択肢${parseInt(index) + 1}`;
+      }
+    });
+  });
+});
+
+
+

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -14,10 +14,35 @@ class Decision < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :category_id, presence: true
 
+  validate :selected_option_presence
   validate :selected_option_must_belong_to_decision
   validate :options_content_uniqueness
 
+  # ⭐ここは既存のままでOK
+
   private
+
+  # =====================================
+  # 🔥 ここに追加（今回の本体）
+  # =====================================
+  before_update :protect_selected_option_from_destroy
+
+  def protect_selected_option_from_destroy
+    return if selected_option_id.blank?
+
+    destroying_ids = options.select(&:marked_for_destruction?).map(&:id)
+
+    if destroying_ids.include?(selected_option_id)
+      errors.add(:base, "最終決断に選ばれている選択肢は削除できません")
+      throw(:abort)
+    end
+  end
+
+  def selected_option_presence
+    return if selected_option_id.present?
+
+    errors.add(:selected_option, "を選択してください")
+  end
 
   def selected_option_must_belong_to_decision
     return if selected_option_id.blank?

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -18,13 +18,8 @@ class Decision < ApplicationRecord
   validate :selected_option_must_belong_to_decision
   validate :options_content_uniqueness
 
-  # ⭐ここは既存のままでOK
-
   private
 
-  # =====================================
-  # 🔥 ここに追加（今回の本体）
-  # =====================================
   before_update :protect_selected_option_from_destroy
 
   def protect_selected_option_from_destroy

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -36,6 +36,17 @@
 
   <hr>
 
+  <% if @decision.persisted? && @decision.options.any? %>
+  <hr>
+
+  <h3>最終決断</h3>
+
+  <div>
+    <%= f.label :selected_option_id, "選択してください" %><br>
+    <%= f.collection_select :selected_option_id, @decision.options, :id, :content, include_blank: true %>
+  </div>
+ <% end %>
+
   <h3>感情</h3>
 
   <% EmotionType.all.each do |emotion| %>

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -12,6 +12,7 @@
 <% end %>
 
 <%= form_with model: @decision, local: true do |f| %>
+
   <div>
     <%= f.label :title, "タイトル" %><br>
     <%= f.text_field :title, class: "form-control mb-3" %>
@@ -23,22 +24,38 @@
   </div>
 
   <hr>
+<h3>選択肢</h3>
 
-  <h3>選択肢</h3>
+<% @decision.options.each_with_index do |option, index| %>
+  <div class="mb-2">
+    <%= text_field_tag "decision[options_attributes][#{index}][content]",
+          option.content,
+          class: "form-control option-input",
+          data: { index: index } %>
+  </div>
+<% end %>
 
-  <%= f.fields_for :options do |option_form| %>
-    <div>
-      <%= option_form.text_field :content %>
-    </div>
-  <% end %>
+<hr>
 
+<h3>最終決断</h3>
+
+<% @decision.options.each_with_index do |option, index| %>
+  <div class="decision-option">
+    <%= radio_button_tag "decision[selected_option_index]", index %>
+    <span id="option-label-<%= index %>">
+      <%= option.content.presence || "選択肢#{index + 1}" %>
+    </span>
+  </div>
+<% end %>
   <hr>
 
   <h3>感情</h3>
 
   <% EmotionType.all.each do |emotion| %>
     <div>
-      <%= check_box_tag "decision[emotion_type_ids][]", emotion.id, @decision.emotion_type_ids.include?(emotion.id) %>
+      <%= check_box_tag "decision[emotion_type_ids][]",
+            emotion.id,
+            @decision.emotion_type_ids.include?(emotion.id) %>
       <%= emotion.name %>
     </div>
   <% end %>
@@ -46,6 +63,7 @@
   <div>
     <%= f.submit "作成する", class: "btn btn-primary w-100" %>
   </div>
+
 <% end %>
 
 <%= link_to "戻る", decisions_path, class: "btn btn-secondary w-100 mt-2" %>

--- a/app/views/decisions/show.html.erb
+++ b/app/views/decisions/show.html.erb
@@ -24,13 +24,46 @@
 
 <ul class="list-group mb-3">
   <% @decision.options.each do |option| %>
-    <li class="list-group-item"><%= option.content %></li>
+    <li class="list-group-item d-flex justify-content-between align-items-center <%= 'list-group-item-success' if @decision.selected_option_id == option.id %>">
+
+      <div>
+        <%= option.content %>
+
+        <% if @decision.selected_option_id == option.id %>
+          <span class="ms-2 badge bg-success">選択中</span>
+        <% end %>
+      </div>
+
+      <div>
+        <%= button_to "これに決める",
+          decision_path(@decision, decision: { selected_option_id: option.id }),
+          method: :patch,
+          class: "btn btn-outline-success btn-sm" %>
+      </div>
+
+    </li>
   <% end %>
 </ul>
 
+<hr>
+
+<h3>最終決断</h3>
+
+<% if @decision.selected_option.present? %>
+  <div class="alert alert-success">
+    <strong><%= @decision.selected_option.content %></strong> を選択しています
+  </div>
+<% else %>
+  <div class="alert alert-secondary">
+    まだ決断していません
+  </div>
+<% end %>
+
+<hr>
+
 <%= form_with model: [@decision, Option.new], local: true do |f| %>
   <%= f.text_field :content, class: "form-control mb-2" %>
-  <%= f.submit "追加" %>
+  <%= f.submit "追加", class: "btn btn-primary" %>
 <% end %>
 
 <hr>


### PR DESCRIPTION
## 概要
最終決断（selected_option）の保存ロジックおよびUIを実装

---

## 変更内容
- 最終決断の保存ロジック実装（2SP）
  - 選択肢から選択した値を `selected_option_id` に保存
  - 作成・更新時に最終決断が正しく反映されるよう対応
  - 選択肢との整合性チェックを追加

- 最終決断UI実装（2SP）
  - 選択肢一覧から最終決断を選択できるUIを追加
  - 選択中の状態が分かる表示を追加
  - 最終決断の結果表示エリアを追加

---

## 確認方法
- 新規作成時に選択肢を入力し最終決断を選択できること
- 作成後に最終決断が正しく表示されること
- 編集時に最終決断の変更・保持ができること

---

## 関連Issue
Closes #92 
Closes #93 