### PR TITLE
add decision-reason-ui

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -16,11 +16,13 @@ class DecisionsController < ApplicationController
   end
 
   def create
-    @decision = current_user.decisions.build(decision_params)
+    @decision = current_user.decisions.new(decision_params)
 
     if @decision.save
-      redirect_to decisions_path, notice: "Decisionを作成しました！"
+      assign_selected_option
+      redirect_to @decision
     else
+      3.times { @decision.options.build } if @decision.options.empty?
       render :new, status: :unprocessable_entity
     end
   end
@@ -34,6 +36,7 @@ class DecisionsController < ApplicationController
     @decision = current_user.decisions.find(params[:id])
 
     if @decision.update(decision_params)
+      assign_selected_option
       redirect_to decision_path(@decision), notice: "更新しました！"
     else
       render :edit, status: :unprocessable_entity
@@ -42,7 +45,11 @@ class DecisionsController < ApplicationController
 
   def destroy
     @decision = current_user.decisions.find(params[:id])
-    @decision.destroy
+
+    Decision.transaction do
+      @decision.update_columns(selected_option_id: nil)
+      @decision.destroy
+    end
 
     redirect_to decisions_path, notice: "削除しました！"
   end
@@ -58,5 +65,14 @@ class DecisionsController < ApplicationController
       options_attributes: [:id, :content, :_destroy],
       emotion_type_ids: []
     )
+  end
+
+  def assign_selected_option
+    return unless params[:decision][:selected_option_index].present?
+
+    index = params[:decision][:selected_option_index].to_i
+    option = @decision.options[index]
+
+    @decision.update_column(:selected_option_id, option&.id)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,18 +4,61 @@ import "controllers"
 
 document.addEventListener("turbo:load", () => {
   const inputs = document.querySelectorAll(".option-input");
+  const radios = document.querySelectorAll(".decision-radio");
+  const preview = document.getElementById("selected-option-preview");
 
   inputs.forEach((input) => {
     input.addEventListener("input", (e) => {
       const index = e.target.dataset.index;
       const label = document.getElementById(`option-label-${index}`);
-
       if (label) {
         label.textContent = e.target.value || `選択肢${parseInt(index) + 1}`;
       }
     });
   });
+
+  radios.forEach((radio) => {
+    radio.addEventListener("change", (e) => {
+      const parent = e.target.closest(".decision-option");
+      const label = parent?.querySelector(".decision-label");
+
+      if (label && preview) {
+        preview.textContent = `${label.textContent} を選択中`;
+      }
+    });
+  });
 });
 
+document.addEventListener("turbo:load", () => {
+  const addBtn = document.getElementById("add-option-btn");
+  const container = document.getElementById("options-container");
+  const template = document.getElementById("option-template");
+
+  if (!addBtn || !container || !template) return;
+
+  let index = container.querySelectorAll(".option-item").length;
+
+  addBtn.addEventListener("click", () => {
+    let newOption = template.innerHTML.replace(/NEW_RECORD/g, index);
+    container.insertAdjacentHTML("beforeend", newOption);
+    index++;
+  });
+});
+
+document.addEventListener("turbo:load", () => {
+  document.addEventListener("click", (e) => {
+    if (e.target.classList.contains("remove-option-btn")) {
+      const item = e.target.closest(".option-item");
+      const destroyInput = item.querySelector(".destroy-flag");
+
+      if (destroyInput) {
+        destroyInput.value = "1";
+        item.style.display = "none";
+      } else {
+        item.remove();
+      }
+    }
+  });
+});
 
 

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -5,7 +5,7 @@ class Decision < ApplicationRecord
 
   has_many :decision_emotions, dependent: :destroy
   has_many :emotion_types, through: :decision_emotions
-  has_many :options, dependent: :destroy
+  has_many :options, dependent: :delete_all
 
   accepts_nested_attributes_for :options,
     allow_destroy: true,
@@ -19,41 +19,45 @@ class Decision < ApplicationRecord
   validate :selected_option_must_belong_to_decision
   validate :options_content_uniqueness
 
+  before_update :clear_selected_option_if_destroyed
+  before_destroy :detach_selected_option
+
   private
 
-  before_update :protect_selected_option_from_destroy
-
-  def protect_selected_option_from_destroy
+  def clear_selected_option_if_destroyed
     return if selected_option_id.blank?
 
     destroying_ids = options.select(&:marked_for_destruction?).map(&:id)
 
-    if destroying_ids.include?(selected_option_id)
-      errors.add(:base, "最終決断に選ばれている選択肢は削除できません")
-      throw(:abort)
-    end
+    return unless destroying_ids.include?(selected_option_id)
+
+    self.selected_option_id = nil
+  end
+
+  def detach_selected_option
+    self.selected_option_id = nil
+    save(validate: false)
   end
 
   def selected_option_presence
-    return if selected_option_id.present?
-
+    return if selected_option_id.present? || new_record?
     errors.add(:selected_option, "を選択してください")
   end
 
   def selected_option_must_belong_to_decision
     return if selected_option_id.blank?
 
-    unless options.where(id: selected_option_id).exists?
-      errors.add(:selected_option, "はこの決断に属する選択肢から選んでください")
-    end
+    return if options.where(id: selected_option_id).exists?
+
+    errors.add(:selected_option, "はこの決断に属する選択肢から選んでください")
   end
 
   def options_content_uniqueness
     contents = options.map(&:content).reject(&:blank?)
 
     duplicates = contents.group_by(&:itself)
-                         .select { |_, v| v.size > 1 }
-                         .keys
+                          .select { |_, v| v.size > 1 }
+                          .keys
 
     duplicates.each do |dup|
       errors.add(:base, "選択肢「#{dup}」が重複しています")

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -1,7 +1,7 @@
 <h1 class="mb-4">決断編集</h1>
 
 <% if @decision.errors.any? %>
-  <div>
+  <div class="alert alert-danger">
     <h2><%= @decision.errors.count %>件のエラーがあります</h2>
     <ul>
       <% @decision.errors.full_messages.each do |message| %>
@@ -12,45 +12,70 @@
 <% end %>
 
 <%= form_with model: @decision, local: true do |f| %>
-  <div>
-    <%= f.label :title, "タイトル" %><br>
-    <%= f.text_field :title, class: "form-control mb-3" %>
+
+  <div class="mb-3">
+    <%= f.label :title, "タイトル" %>
+    <%= f.text_field :title, class: "form-control" %>
   </div>
 
-  <div>
-    <%= f.label :category_id, "カテゴリ" %><br>
-    <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "選択してください" %>
+  <div class="mb-3">
+    <%= f.label :category_id, "カテゴリ" %>
+    <%= f.collection_select :category_id, Category.all, :id, :name,
+        { prompt: "選択してください" },
+        { class: "form-select" } %>
   </div>
 
   <hr>
 
   <h3>選択肢</h3>
 
-  <%= f.fields_for :options do |option_form| %>
-    <div>
-      <%= option_form.text_field :content %>
-      <%= option_form.check_box :_destroy %>
-      <%= option_form.label :_destroy, "削除" %>
+  <div id="options-container">
+    <%= f.fields_for :options do |option_form| %>
+      <div class="mb-2 option-item">
+        <%= option_form.text_field :content, class: "form-control" %>
+
+        <%= option_form.hidden_field :_destroy, class: "destroy-flag" %>
+
+        <button type="button" class="remove-option-btn btn btn-danger btn-sm mt-1">
+          削除
+        </button>
+      </div>
+    <% end %>
+  </div>
+
+  <button type="button" id="add-option-btn" class="btn btn-outline-primary mb-3">
+    ＋ 選択肢を追加
+  </button>
+
+  <div id="option-template" style="display: none;">
+    <div class="mb-2 option-item">
+      <input type="text"
+             name="decision[options_attributes][NEW_RECORD][content]"
+             class="form-control" />
+
+      <button type="button" class="remove-option-btn btn btn-danger btn-sm mt-1">
+        削除
+      </button>
     </div>
-  <% end %>
+  </div>
 
   <hr>
 
   <% if @decision.persisted? && @decision.options.any? %>
-  <hr>
+    <h3>最終決断</h3>
 
-  <h3>最終決断</h3>
+    <% @decision.options.reject(&:marked_for_destruction?).each do |option| %>
+      <div class="decision-option mb-1">
+        <%= f.radio_button :selected_option_id, option.id %>
+        <span><%= option.content.presence || "選択肢" %></span>
+      </div>
+    <% end %>
 
-  <div>
-    <%= f.label :selected_option_id, "選択してください" %><br>
-    <%= f.collection_select :selected_option_id, @decision.options, :id, :content, include_blank: true %>
-  </div>
- <% end %>
-
-  <div>
-  <%= f.label :reason, "決断理由" %>
-  <%= f.text_area :reason, class: "form-control" %>
-  </div>
+    <div class="mb-3 mt-3">
+      <%= f.label :reason, "決断理由" %>
+      <%= f.text_area :reason, class: "form-control", rows: 3 %>
+    </div>
+  <% end %>
 
   <hr>
 
@@ -58,14 +83,27 @@
 
   <% EmotionType.all.each do |emotion| %>
     <div>
-      <%= check_box_tag "decision[emotion_type_ids][]", emotion.id, @decision.emotion_type_ids.include?(emotion.id) %>
+      <%= check_box_tag "decision[emotion_type_ids][]",
+          emotion.id,
+          @decision.emotion_type_ids.include?(emotion.id) %>
       <%= emotion.name %>
     </div>
   <% end %>
 
-  <div>
+  <div class="mt-3">
     <%= f.submit "更新する", class: "btn btn-primary w-100" %>
   </div>
+
 <% end %>
 
-<%= link_to "戻る", decision_path(@decision), class: "btn btn-secondary w-100 mt-2" %>
+<div class="mt-3">
+  <%= button_to "この決断を削除する",
+      decision_path(@decision),
+      method: :delete,
+      data: { turbo_confirm: "本当に削除しますか？" },
+      class: "btn btn-danger w-100" %>
+</div>
+
+<%= link_to "戻る",
+    decision_path(@decision),
+    class: "btn btn-secondary w-100 mt-2" %>

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -24,35 +24,37 @@
   </div>
 
   <hr>
-<h3>選択肢</h3>
 
-<% @decision.options.each_with_index do |option, index| %>
-  <div class="mb-2">
-    <%= text_field_tag "decision[options_attributes][#{index}][content]",
-          option.content,
-          class: "form-control option-input",
-          data: { index: index } %>
-  </div>
-<% end %>
+  <h3>選択肢</h3>
 
-<hr>
+  <% @decision.options.each_with_index do |option, index| %>
+    <div class="mb-2">
+      <%= text_field_tag "decision[options_attributes][#{index}][content]",
+            option.content,
+            class: "form-control option-input",
+            data: { index: index } %>
+    </div>
+  <% end %>
 
-<h3>最終決断</h3>
-
-<% @decision.options.each_with_index do |option, index| %>
-  <div class="decision-option">
-    <%= radio_button_tag "decision[selected_option_index]", index %>
-    <span id="option-label-<%= index %>">
-      <%= option.content.presence || "選択肢#{index + 1}" %>
-    </span>
-  </div>
-<% end %>
   <hr>
 
-  <div>
-  <%= f.label :reason, "決断理由" %>
-  <%= f.text_area :reason, class: "form-control" %>
- </div>
+  <h3>最終決断</h3>
+
+  <% @decision.options.each_with_index do |option, index| %>
+    <div class="decision-option">
+      <%= radio_button_tag "decision[selected_option_index]", index, false, class: "decision-radio" %>
+      <span class="decision-label" id="option-label-<%= index %>">
+        <%= option.content.presence || "選択肢#{index + 1}" %>
+      </span>
+    </div>
+  <% end %>
+
+  <hr>
+
+  <div class="mb-3">
+    <%= f.label :reason, "決断理由" %>
+    <%= f.text_area :reason, class: "form-control", rows: 3 %>
+  </div>
 
   <hr>
 

--- a/app/views/decisions/show.html.erb
+++ b/app/views/decisions/show.html.erb
@@ -61,22 +61,22 @@
 
 <hr>
 
- <% if @decision.reason.present? %>
-  <p><%= @decision.reason %></p>
- <% end %>
+<h3>決断理由</h3>
 
-<hr>
-
-<%= form_with model: [@decision, Option.new], local: true do |f| %>
-  <%= f.text_field :content, class: "form-control mb-2" %>
-  <%= f.submit "追加", class: "btn btn-primary" %>
+<% if @decision.reason.present? %>
+  <div class="alert alert-secondary">
+    <%= @decision.reason %>
+  </div>
+<% else %>
+  <div class="text-muted">
+    理由はまだ記録されていません
+  </div>
 <% end %>
 
 <hr>
 
 <div class="d-flex gap-2">
   <%= link_to "編集", edit_decision_path(@decision), class: "btn btn-warning" %>
-  <%= link_to "削除", decision_path(@decision),
-      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-      class: "btn btn-danger" %>
 </div>
+
+<%= link_to "一覧に戻る", decisions_path, class: "btn btn-secondary w-100 mt-3" %>


### PR DESCRIPTION
## 概要
決断理由入力・表示機能を追加

## 変更内容
- decisionsテーブルの `reason` を保存・更新できるよう対応
- strong parameters に `:reason` を追加
- new / edit フォームに決断理由入力欄（textarea）を追加
- show画面に決断理由の表示を追加

## 確認方法
- 新規決断作成時に理由を入力できること
- 編集画面で理由を更新できること
- 詳細画面で理由が表示されること
- 未入力でも保存できること

## 関連Issue
Closes #95 