### PR TITLE
add date-to-decision-emotions

### DIFF
--- a/app/models/decision_emotion.rb
+++ b/app/models/decision_emotion.rb
@@ -1,4 +1,6 @@
 class DecisionEmotion < ApplicationRecord
   belongs_to :decision
   belongs_to :emotion_type
+
+  validates :recorded_on, presence: true
 end

--- a/db/migrate/20260427134204_add_date_to_decision_emotions.rb
+++ b/db/migrate/20260427134204_add_date_to_decision_emotions.rb
@@ -1,0 +1,5 @@
+class AddDateToDecisionEmotions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :decision_emotions, :recorded_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_25_104635) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_134204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_104635) do
     t.datetime "created_at", null: false
     t.bigint "decision_id", null: false
     t.bigint "emotion_type_id", null: false
+    t.date "recorded_on"
     t.datetime "updated_at", null: false
     t.index ["decision_id"], name: "index_decision_emotions_on_decision_id"
     t.index ["emotion_type_id"], name: "index_decision_emotions_on_emotion_type_id"


### PR DESCRIPTION
## 概要
decision_emotionsに日付カラム（recorded_on）を追加

## 変更内容
- decision_emotionsテーブルに `recorded_on`（date型）カラムを追加
- マイグレーションを作成・実行
- コンソールで保存・取得できることを確認

## 確認方法
- `rails db:migrate` を実行
- Railsコンソールで以下を実行

## 関連Issue
Closes #96 