### PR TITLE
感情作成に日付選択追加

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -1,12 +1,13 @@
 class DecisionsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_decision, only: [:show, :edit, :update, :destroy]
+  before_action :set_emotion_types, only: [:new, :create, :edit, :update]
 
   def index
     @decisions = current_user.decisions.order(created_at: :desc)
   end
 
   def show
-    @decision = current_user.decisions.find(params[:id])
     @options = @decision.options
   end
 
@@ -20,23 +21,22 @@ class DecisionsController < ApplicationController
 
     if @decision.save
       assign_selected_option
+      save_emotions_with_date
       redirect_to @decision
     else
-      3.times { @decision.options.build } if @decision.options.empty?
+      build_options_if_empty
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
-    @decision = current_user.decisions.find(params[:id])
-    @decision.options.build if @decision.options.empty?
+    build_options_if_empty
   end
 
   def update
-    @decision = current_user.decisions.find(params[:id])
-
     if @decision.update(decision_params)
       assign_selected_option
+      save_emotions_with_date
       redirect_to decision_path(@decision), notice: "更新しました！"
     else
       render :edit, status: :unprocessable_entity
@@ -44,8 +44,6 @@ class DecisionsController < ApplicationController
   end
 
   def destroy
-    @decision = current_user.decisions.find(params[:id])
-
     Decision.transaction do
       @decision.update_columns(selected_option_id: nil)
       @decision.destroy
@@ -56,23 +54,60 @@ class DecisionsController < ApplicationController
 
   private
 
+  def set_decision
+    @decision = current_user.decisions.find(params[:id])
+  end
+
+  def set_emotion_types
+    @emotion_types = EmotionType.all
+  end
+
+  def build_options_if_empty
+    3.times { @decision.options.build } if @decision.options.empty?
+  end
+
   def decision_params
     params.require(:decision).permit(
       :title,
       :category_id,
       :selected_option_id,
       :reason,
-      options_attributes: [:id, :content, :_destroy],
-      emotion_type_ids: []
+      options_attributes: [:id, :content, :_destroy]
     )
   end
 
   def assign_selected_option
-    return unless params[:decision][:selected_option_index].present?
+    return unless params.dig(:decision, :selected_option_index).present?
 
     index = params[:decision][:selected_option_index].to_i
     option = @decision.options[index]
 
     @decision.update_column(:selected_option_id, option&.id)
   end
+
+def save_emotions_with_date
+  emotion_ids = params.dig(:decision, :emotion_type_ids)&.reject(&:blank?)
+  recorded_on_param = params.dig(:decision, :recorded_on)
+
+  return if recorded_on_param.blank?
+
+  recorded_on = begin
+    Date.parse(recorded_on_param)
+  rescue
+    nil
+  end
+
+  return if recorded_on.nil?
+
+  @decision.decision_emotions.destroy_all
+
+  if emotion_ids.present?
+    emotion_ids.each do |emotion_id|
+      @decision.decision_emotions.create(
+        emotion_type_id: emotion_id,
+        recorded_on: recorded_on
+      )
+    end
+  end
+end
 end

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -18,6 +18,10 @@
     <%= f.text_field :title, class: "form-control" %>
   </div>
 
+  <h3>日付</h3>
+
+  <%= date_field_tag "decision[recorded_on]", nil, class: "form-control" %>
+
   <div class="mb-3">
     <%= f.label :category_id, "カテゴリ" %>
     <%= f.collection_select :category_id, Category.all, :id, :name,

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -1,9 +1,9 @@
 <h1 class="mb-4">決断作成</h1>
 
 <% if @decision.errors.any? %>
-  <div>
-    <h2><%= @decision.errors.count %>件のエラーがあります</h2>
-    <ul>
+  <div class="alert alert-danger">
+    <h5><%= @decision.errors.count %>件のエラーがあります</h5>
+    <ul class="mb-0">
       <% @decision.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
@@ -13,19 +13,28 @@
 
 <%= form_with model: @decision, local: true do |f| %>
 
-  <div>
-    <%= f.label :title, "タイトル" %><br>
-    <%= f.text_field :title, class: "form-control mb-3" %>
+  <div class="mb-3">
+    <%= f.label :title, "タイトル" %>
+    <%= f.text_field :title, class: "form-control" %>
   </div>
 
-  <div>
-    <%= f.label :category_id, "カテゴリ" %><br>
-    <%= f.collection_select :category_id, Category.all, :id, :name, prompt: "選択してください" %>
+    <div class="mb-3">
+    <%= label_tag nil, "日付" %>
+    <%= date_field_tag "decision[recorded_on]",
+          Date.today,
+          class: "form-control",
+          required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :category_id, "カテゴリ" %>
+    <%= f.collection_select :category_id, Category.all, :id, :name,
+          { prompt: "選択してください" }, class: "form-select" %>
   </div>
 
   <hr>
 
-  <h3>選択肢</h3>
+  <h5>選択肢</h5>
 
   <% @decision.options.each_with_index do |option, index| %>
     <div class="mb-2">
@@ -38,16 +47,27 @@
 
   <hr>
 
-  <h3>最終決断</h3>
+<h5>最終決断</h5>
 
-  <% @decision.options.each_with_index do |option, index| %>
-    <div class="decision-option">
-      <%= radio_button_tag "decision[selected_option_index]", index, false, class: "decision-radio" %>
-      <span class="decision-label" id="option-label-<%= index %>">
-        <%= option.content.presence || "選択肢#{index + 1}" %>
-      </span>
-    </div>
-  <% end %>
+<% @decision.options.each_with_index do |option, index| %>
+  <div class="decision-option form-check">
+    <%= radio_button_tag "decision[selected_option_index]",
+          index,
+          false,
+          id: "option_#{index}",
+          class: "form-check-input decision-radio" %>
+
+    <%= label_tag "option_#{index}",
+          (option.content.presence || "選択肢#{index + 1}"),
+          class: "form-check-label decision-label",
+          id: "option-label-#{index}" %>
+  </div>
+<% end %>
+
+<div class="mt-3">
+  <strong>選択中：</strong>
+  <span id="selected-option-preview" class="text-success">未選択</span>
+</div>
 
   <hr>
 
@@ -58,18 +78,23 @@
 
   <hr>
 
-  <h3>感情</h3>
+  <h5>感情</h5>
 
-  <% EmotionType.all.each do |emotion| %>
-    <div>
+  <% @emotion_types.each do |emotion| %>
+    <div class="form-check">
       <%= check_box_tag "decision[emotion_type_ids][]",
             emotion.id,
-            @decision.emotion_type_ids.include?(emotion.id) %>
-      <%= emotion.name %>
+            false,
+            id: "emotion_#{emotion.id}",
+            class: "form-check-input" %>
+
+      <%= label_tag "emotion_#{emotion.id}",
+            emotion.name,
+            class: "form-check-label" %>
     </div>
   <% end %>
 
-  <div>
+  <div class="mt-4">
     <%= f.submit "作成する", class: "btn btn-primary w-100" %>
   </div>
 

--- a/app/views/decisions/show.html.erb
+++ b/app/views/decisions/show.html.erb
@@ -3,20 +3,34 @@
 <div class="card mb-4">
   <div class="card-body">
     <h2 class="card-title"><%= @decision.title %></h2>
-    <p class="card-text">カテゴリ: <%= @decision.category&.name || "未設定" %></p>
-    <p class="card-text">作成日: <%= @decision.created_at.strftime("%Y/%m/%d") %></p>
+     <% date = @decision.decision_emotions.first.recorded_on %>
+
+  <p class="card-text" mb-2">
+    日付：
+    <%= date == Date.today ? "今日" : date.strftime("%Y年%m月%d日") %>
+  </p>
+    <p class="card-text">
+      カテゴリ: <%= @decision.category&.name || "未設定" %>
+    </p>
   </div>
 </div>
 
 <hr>
 
-<h3>感情</h3>
+<h3 class="mb-3">感情</h3>
 
-<div class="mb-3">
-  <% @decision.emotion_types.each do |emotion| %>
-    <span class="badge bg-primary me-1"><%= emotion.name %></span>
-  <% end %>
-</div>
+<% if @decision.decision_emotions.present? %>
+
+  <div class="mb-3">
+    <% @decision.decision_emotions.each do |de| %>
+      <span class="badge bg-primary me-1 mb-1">
+        <%= de.emotion_type.name %>
+      </span>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-muted">感情はまだ記録されていません</p>
+<% end %>
 
 <hr>
 
@@ -34,12 +48,10 @@
         <% end %>
       </div>
 
-      <div>
-        <%= button_to "これに決める",
-          decision_path(@decision, decision: { selected_option_id: option.id }),
-          method: :patch,
-          class: "btn btn-outline-success btn-sm" %>
-      </div>
+      <%= button_to "これに決める",
+        decision_path(@decision, decision: { selected_option_id: option.id }),
+        method: :patch,
+        class: "btn btn-outline-success btn-sm" %>
 
     </li>
   <% end %>
@@ -68,9 +80,9 @@
     <%= @decision.reason %>
   </div>
 <% else %>
-  <div class="text-muted">
+  <p class="text-muted">
     理由はまだ記録されていません
-  </div>
+  </p>
 <% end %>
 
 <hr>


### PR DESCRIPTION
## 概要
感情記録に日付選択機能を追加

## 変更内容
- 感情に日付を設定できるようフォームに日付入力を追加
- `DecisionEmotion` に `recorded_on` を保存する処理を実装
- create / update 時に感情と日付をまとめて保存するよう修正
- 詳細画面で感情と日付を表示するよう修正

## 確認方法
- 決断作成画面で感情と日付を入力して保存できること
- 詳細画面で日付付きの感情が表示されること
- 編集画面で日付を変更して更新できること

## 関連Issue
Closes #97 