### PR TITLE
初回ガイドモーダル&サイドバー作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,12 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    if !resource.first_login_done?
-      resource.update(first_login_done: true)
-      guide_path
-    else
-      super
-    end
+    root_path
   end
 
   protected

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -12,8 +12,9 @@ class DecisionsController < ApplicationController
   end
 
   def new
-    @decision = Decision.new
-    3.times { @decision.options.build }
+   @decision = Decision.new
+   @emotion_types = EmotionType.all
+   3.times { @decision.options.build }
   end
 
   def create

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,4 +1,11 @@
 class GuidesController < ApplicationController
+  before_action :authenticate_user!
+
   def show
+  end
+
+  def complete
+    current_user.update(first_login_done: true)
+    redirect_to new_decision_path
   end
 end

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -1,4 +1,25 @@
+<%= render "shared/guide_modal" %>
+<% if current_user && !current_user.first_login_done? %>
+  <script>
+    document.addEventListener("turbo:load", function () {
+      const el = document.getElementById("guideModal");
+      if (!el) return;
+
+      const modal = new bootstrap.Modal(el);
+      modal.show();
+    });
+  </script>
+<% end %>
+
 <h1 class="mb-4">決断作成</h1>
+
+<% if controller_name == "decisions" && action_name == "new" %>
+  <button class="btn btn-outline-info btn-sm"
+          data-bs-toggle="modal"
+          data-bs-target="#guideModal">
+    ガイド
+  </button>
+<% end %>
 
 <% if @decision.errors.any? %>
   <div class="alert alert-danger">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,36 +24,62 @@
 
   <body>
 
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <div class="container">
-        <%= link_to "LifeBranch", decisions_path, class: "navbar-brand" %>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container">
+      <%= link_to "LifeBranch", decisions_path, class: "navbar-brand" %>
 
-        <% if user_signed_in? %>
-           <span><%= current_user.name %>さん</span>
-        <% end %>
-
-        <div>
-          <% if user_signed_in? %>
-            <%= link_to "ログアウト", destroy_user_session_path, class: "btn btn-outline-danger btn-sm", data: { turbo_method: :delete } %>
-          <% else %>
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline-primary btn-sm me-2" %>
-            <%= link_to "新規登録", new_user_registration_path, class: "btn btn-primary btn-sm" %>
-          <% end %>
-        </div>
-      </div>
-    </nav>
-
-    <div class="container mt-4">
-
-      <% flash.each do |type, message| %>
-        <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
-          <%= message %>
-        </div>
+      <% if user_signed_in? %>
+        <span><%= current_user.name %>さん</span>
       <% end %>
 
-      <%= yield %>
+      <div>
+        <% if user_signed_in? %>
+          <%= link_to "ログアウト", destroy_user_session_path,
+              class: "btn btn-outline-danger btn-sm",
+              data: { turbo_method: :delete } %>
+        <% else %>
+          <%= link_to "ログイン", new_user_session_path,
+              class: "btn btn-outline-primary btn-sm me-2" %>
+          <%= link_to "新規登録", new_user_registration_path,
+              class: "btn btn-primary btn-sm" %>
+        <% end %>
+      </div>
     </div>
+  </nav>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  </body>
+  <div class="container-fluid">
+    <div class="row">
+
+      <div class="col-md-3 bg-light min-vh-100 p-3">
+
+        <ul class="nav flex-column">
+          <li class="nav-item">
+            <%= link_to "ダッシュボード", decisions_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "一覧", decisions_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "新規作成", new_decision_path, class: "nav-link" %>
+          </li>
+        </ul>
+      </div>
+
+      <div class="col-md-9 p-4">
+
+        <% flash.each do |type, message| %>
+          <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
+            <%= message %>
+          </div>
+        <% end %>
+
+        <%= yield %>
+
+      </div>
+
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
 </html>

--- a/app/views/shared/_guide_modal.html.erb
+++ b/app/views/shared/_guide_modal.html.erb
@@ -1,0 +1,21 @@
+<div class="modal fade" id="guideModal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content p-4">
+
+      <h4>入力ガイド</h4>
+
+      <p>
+        ・タイトルを書く<br>
+        ・選択肢を複数追加<br>
+        ・1つ選んで決断
+      </p>
+
+      <%= button_to "理解した",
+      complete_guide_path,
+      method: :post,
+      form: { data: { turbo: false } },
+      class: "btn btn-primary w-100" %>
+
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,22 +3,21 @@ Rails.application.routes.draw do
 
   root "home#index"
 
-  get "guide", to: "guides#show"
+   get "guide", to: "guides#show"
+   post "complete_guide", to: "guides#complete"
 
-  resources :decisions, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+   resources :decisions, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
+    resources :options, only: [:create]
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+   get "up" => "rails/health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
- resources :decisions do
-  resources :options, only: [:create]
- end
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/db/migrate/20260506112343_change_first_login_done_default.rb
+++ b/db/migrate/20260506112343_change_first_login_done_default.rb
@@ -1,0 +1,5 @@
+class ChangeFirstLoginDoneDefault < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :users, :first_login_done, from: true, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_142114) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_112343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -65,7 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_142114) do
     t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.boolean "first_login_done", default: true, null: false
+    t.boolean "first_login_done", default: false, null: false
     t.datetime "last_sign_in_at"
     t.string "last_sign_in_ip"
     t.string "name"


### PR DESCRIPTION
## 概要

Indexページにサイドバー追加および初回ガイドモーダル機能を実装

## 変更内容

* Indexページにサイドバーを追加
* 新規作成（newページ）にガイドボタンを追加
* 初回アクセス時のみ表示されるガイドモーダルを実装
* ガイド確認後に `first_login_done` を更新する処理を追加
* モーダルを共通パーシャルとして切り出し

## 確認方法

* 初回のみガイドモーダルが表示されることを確認
* 「理解した」を押すとモーダルが閉じ、再表示されないことを確認
* newページの「ガイド」ボタンからモーダルが再表示できることを確認
* Indexページにサイドバーが表示されていることを確認

## 関連Issue

Closes #99 
