### PR TITLE
プロフィールメニュー&プロフ画像アップロード機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,13 +5,20 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    root_path
+    dashboard_path
   end
 
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(
+      :sign_up,
+      keys: [:name, :avatar]
+    )
+
+    devise_parameter_sanitizer.permit(
+      :account_update,
+      keys: [:name, :avatar]
+    )
   end
 end

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,7 +1,7 @@
 class GuidesController < ApplicationController
-  before_action :authenticate_user!
 
   def show
+    redirect_to dashboard_path if user_signed_in?
   end
 
   def complete

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,5 +10,6 @@ class User < ApplicationRecord
   end
 
   validates :name, presence: true, length: { maximum: 50 }
+  has_one_attached :avatar
   has_many :decisions, dependent: :destroy
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title><%= content_for(:title) || "Life Branch" %></title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Life Branch">
     <meta name="mobile-web-app-capable" content="yes">
@@ -28,19 +29,65 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
       <div class="container-fluid">
 
-        <%= link_to "LifeBranch", root_path, class: "navbar-brand" %>
+        <%= link_to "LifeBranch", root_path, class: "navbar-brand", data: { turbo: false } %>
 
-        <div class="d-flex align-items-center gap-3">
+        <% if user_signed_in? %>
 
-          <% if user_signed_in? %>
-            <span><%= current_user.name %>さん</span>
+         <div id="user-menu" class="dropdown" data-turbo-permanent>
+            <button
+              class="btn border-0 dropdown-toggle d-flex align-items-center gap-2"
+              type="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false">
 
-            <%= link_to "ログアウト",
-                  destroy_user_session_path,
-                  class: "btn btn-outline-danger btn-sm",
-                  data: { turbo_method: :delete } %>
+              <% if current_user.avatar.attached? %>
 
-          <% else %>
+                <%= image_tag current_user.avatar,
+                      width: 40,
+                      height: 40,
+                      class: "rounded-circle object-fit-cover" %>
+
+              <% else %>
+
+                <div
+                  class="rounded-circle bg-secondary text-white d-flex justify-content-center align-items-center"
+                  style="width: 40px; height: 40px;">
+                </div>
+
+              <% end %>
+
+            </button>
+
+            <ul class="dropdown-menu dropdown-menu-end">
+
+              <li class="dropdown-item-text fw-bold">
+                <%= current_user.name %>
+              </li>
+
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+
+              <li>
+                <%= link_to "プロフィール編集",
+                      edit_user_registration_path,
+                      class: "dropdown-item" %>
+              </li>
+
+              <li>
+                <%= link_to "ログアウト",
+                      destroy_user_session_path,
+                      class: "dropdown-item text-danger",
+                      data: { turbo_method: :delete } %>
+              </li>
+
+            </ul>
+
+          </div>
+
+        <% else %>
+
+          <div class="d-flex gap-2">
 
             <%= link_to "ログイン",
                   new_user_session_path,
@@ -50,9 +97,10 @@
                   new_user_registration_path,
                   class: "btn btn-primary btn-sm" %>
 
-          <% end %>
+          </div>
 
-        </div>
+        <% end %>
+
       </div>
     </nav>
 
@@ -62,37 +110,50 @@
         <% if user_signed_in? %>
 
           <aside class="col-md-3 col-lg-2 bg-light min-vh-100 border-end p-3">
+
             <ul class="nav flex-column">
 
               <li class="nav-item mb-2">
                 <%= link_to "ダッシュボード",
-                      root_path,
-                      class: "nav-link" %>
+                      dashboard_path,
+                      class: "nav-link",
+                      data: { turbo: false } %>
               </li>
 
               <li class="nav-item mb-2">
                 <%= link_to "意思決定一覧",
                       decisions_path,
-                      class: "nav-link" %>
+                      class: "nav-link",
+                      data: { turbo: false } %>
               </li>
             </ul>
+
           </aside>
+
           <main class="col-md-9 col-lg-10 p-4">
+
         <% else %>
+
           <main class="col-12 p-4">
+
         <% end %>
 
             <% flash.each do |type, message| %>
+
               <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
                 <%= message %>
               </div>
+
             <% end %>
 
             <%= yield %>
+
           </main>
+
       </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  root "home#index"
+  root "guides#show"
 
-   get "guide", to: "guides#show"
+   get "dashboard", to: "home#index"
    post "complete_guide", to: "guides#complete"
 
    resources :decisions, only: [:index, :show, :new, :create, :edit, :update, :destroy] do

--- a/db/migrate/20260507074319_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260507074319_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_112343) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_074319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "categories", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -78,6 +106,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_112343) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "decision_emotions", "decisions"
   add_foreign_key "decision_emotions", "emotion_types"
   add_foreign_key "decisions", "categories"


### PR DESCRIPTION
## 概要
プロフィールメニューの追加およびプロフィール画像アップロード機能の実装

## 変更内容
- ヘッダーにプロフィールメニュー（ドロップダウン）を追加
- プロフィール画像をヘッダーに表示
- 画像クリックでメニュー表示（名前・プロフィール編集・ログアウト）
- Active Storage を用いたプロフィール画像アップロード対応
- BootstrapドロップダウンUIを適用

## 確認方法
- ログイン後、ヘッダーにプロフィール画像が表示されることを確認
- 画像クリックでメニューが開くことを確認

## 関連Issue
Closes #102 