### PR TITLE
カテゴリ検索機能を追加

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -32,7 +32,11 @@ class Decision < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["title"]
+    ["title", "category_id"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["category"]
   end
 
   def clear_selected_option_if_destroyed

--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -13,6 +13,13 @@
         class: "form-control",
         placeholder: "タイトルで検索" %>
 
+  <%= f.collection_select :category_id_eq,
+      Category.all,
+      :id,
+      :name,
+      { include_blank: "すべてのカテゴリ" },
+      { class: "form-select" } %>
+
   <%= f.submit "検索",
         class: "btn btn-outline-secondary" %>
 


### PR DESCRIPTION
## 変更内容
- Ransackを利用したカテゴリ検索機能を追加
- カテゴリ選択用プルダウンを検索フォームに追加
- `Decision`モデルに`ransackable_associations`を追加
- タイトル検索とカテゴリ検索を組み合わせて検索できるように対応

## 確認方法
- 意思決定一覧画面へアクセス
- カテゴリを選択して検索できることを確認
- タイトル検索とカテゴリ検索を組み合わせても検索できることを確認

## 関連Issue
Closes #136 