### PR TITLE
日付検索機能

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -16,6 +16,7 @@ class Decision < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :category_id, presence: true
   validates :reason, length: { maximum: 1000 }, allow_blank: true
+  validates :recorded_on, presence: true
 
   validate :options_presence
   validate :options_content_uniqueness
@@ -32,7 +33,7 @@ class Decision < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["title", "category_id"]
+    ["title", "category_id", "recorded_on"]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -20,6 +20,9 @@
       { include_blank: "すべてのカテゴリ" },
       { class: "form-select" } %>
 
+  <%= f.date_field :recorded_on_eq,
+        class: "form-control" %>
+
   <%= f.submit "検索",
         class: "btn btn-outline-secondary" %>
 


### PR DESCRIPTION
## 概要
意思決定一覧に日付検索機能を追加し、意思決定作成時に記録日の入力を必須にしました。

## 変更内容
- Ransackを利用した日付検索機能を追加
- 一覧画面に日付検索フォームを追加
- `recorded_on` を必須バリデーションに変更
- 新規作成フォームで記録日を必須入力に変更

## 確認方法
- `localhost:3000/decisions` にアクセス
- 記録日を指定して検索できること
- 該当日の意思決定のみ表示されること
- 記録日未入力で新規登録するとバリデーションエラーになること
- 記録日を入力すると正常に登録できること

## 関連Issue
Closes #137 