### PR TITLE
並び替え機能追加

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -5,7 +5,10 @@ class DecisionsController < ApplicationController
 
   def index
     @q = current_user.decisions.ransack(params[:q])
-    @decisions = @q.result(distinct: true).order(created_at: :desc)
+
+    @q.sorts = "created_at desc" if @q.sorts.empty?
+
+    @decisions = @q.result(distinct: true)
   end
 
   def show

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -33,7 +33,7 @@ class Decision < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["title", "category_id", "recorded_on"]
+    ["title", "category_id", "recorded_on", "created_at"]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -30,6 +30,13 @@
 
 </div>
 
+<div class="mb-3">
+  並び替え：
+  <%= sort_link(@q, :created_at, "作成日") %> |
+  <%= sort_link(@q, :recorded_on, "記録日") %> |
+  <%= sort_link(@q, :title, "タイトル") %>
+</div>
+
 <% if @decisions.any? %>
 
   <% @decisions.each do |decision| %>


### PR DESCRIPTION
## 概要
意思決定一覧に並び替え機能を実装

## 変更内容
- Ransackの`sort_link`を利用して並び替え機能を追加
- 作成日の昇順・降順で並び替え可能に変更
- タイトルの昇順・降順で並び替え可能に変更

## 確認方法
- `localhost:3000/decisions` にアクセス
- 「作成日」をクリックし、昇順・降順に切り替わることを確認
- 「タイトル」をクリックし、昇順・降順に切り替わることを確認

## 関連Issue
Closes #138 