### PR TITLE
検索機能UI調整

### DIFF
--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -1,79 +1,106 @@
 <h1 class="mb-4">意思決定一覧</h1>
 
-<div class="d-flex gap-2 mb-4 align-items-center">
-
+<div class="d-flex justify-content-end mb-3">
   <%= link_to "＋ 新規作成",
-        new_decision_path,
-        class: "btn btn-primary" %>
-
-  <%= search_form_for @q,
-      class: "d-flex gap-2 flex-grow-1" do |f| %>
-
-  <%= f.search_field :title_cont,
-        class: "form-control",
-        placeholder: "タイトルで検索" %>
-
-  <%= f.collection_select :category_id_eq,
-      Category.all,
-      :id,
-      :name,
-      { include_blank: "すべてのカテゴリ" },
-      { class: "form-select" } %>
-
-  <%= f.date_field :recorded_on_eq,
-        class: "form-control" %>
-
-  <%= f.submit "検索",
-        class: "btn btn-outline-secondary" %>
-
-<% end %>
-
+      new_decision_path,
+      class: "btn btn-primary" %>
 </div>
 
-<div class="mb-3">
-  並び替え：
-  <%= sort_link(@q, :created_at, "作成日") %> |
-  <%= sort_link(@q, :recorded_on, "記録日") %> |
-  <%= sort_link(@q, :title, "タイトル") %>
+<div class="card shadow-sm mb-4">
+  <div class="card-body">
+
+    <%= search_form_for @q do |f| %>
+
+      <div class="row g-3 align-items-end">
+
+        <div class="col-md-4">
+          <%= f.label :title_cont, "タイトル", class: "form-label" %>
+          <%= f.search_field :title_cont,
+                class: "form-control",
+                placeholder: "タイトルで検索" %>
+        </div>
+
+        <div class="col-md-3">
+          <%= f.label :category_id_eq, "カテゴリ", class: "form-label" %>
+          <%= f.collection_select :category_id_eq,
+                Category.all,
+                :id,
+                :name,
+                { include_blank: "すべて" },
+                { class: "form-select" } %>
+        </div>
+
+        <div class="col-md-3">
+          <%= f.label :recorded_on_eq, "記録日", class: "form-label" %>
+          <%= f.date_field :recorded_on_eq,
+                class: "form-control" %>
+        </div>
+
+        <div class="col-md-2 d-grid">
+          <%= f.submit "検索",
+                class: "btn btn-primary" %>
+        </div>
+
+      </div>
+
+    <% end %>
+
+    <hr>
+
+    <div class="d-flex flex-wrap gap-2 align-items-center">
+      <span class="fw-bold text-muted">並び替え</span>
+
+      <%= sort_link(@q, :created_at, "作成日",
+            class: "btn btn-sm btn-outline-secondary") %>
+
+      <%= sort_link(@q, :recorded_on, "記録日",
+            class: "btn btn-sm btn-outline-secondary") %>
+
+      <%= sort_link(@q, :title, "タイトル",
+            class: "btn btn-sm btn-outline-secondary") %>
+    </div>
+
+  </div>
 </div>
 
 <% if @decisions.any? %>
 
   <% @decisions.each do |decision| %>
 
-    <div class="border rounded p-3 mb-3">
+    <div class="card shadow-sm mb-3">
+      <div class="card-body">
 
-      <div class="d-flex justify-content-between align-items-center mb-2">
+        <div class="d-flex justify-content-between align-items-center mb-2">
 
-        <h5 class="mb-0">
-          <%= link_to decision.title,
-                decision_path(decision),
-                class: "text-decoration-none" %>
-        </h5>
+          <h5 class="mb-0">
+            <%= link_to decision.title,
+                  decision_path(decision),
+                  class: "text-decoration-none" %>
+          </h5>
 
-        <small class="text-muted">
-          <% if decision.recorded_on.present? %>
-            <%= decision.recorded_on.strftime("%Y/%m/%d") %>
-          <% else %>
-            <%= decision.created_at.strftime("%Y/%m/%d") %>
-          <% end %>
-        </small>
+          <small class="text-muted">
+            <% if decision.recorded_on.present? %>
+              <%= decision.recorded_on.strftime("%Y/%m/%d") %>
+            <% else %>
+              <%= decision.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+          </small>
 
-      </div>
+        </div>
 
-      <!-- カテゴリ -->
-      <div>
         <span class="badge bg-secondary">
           <%= decision.category&.name || "未設定" %>
         </span>
-      </div>
 
+      </div>
     </div>
 
   <% end %>
 
 <% else %>
 
-  <p class="text-muted">まだ意思決定がありません</p>
+  <div class="alert alert-light text-center">
+    まだ意思決定がありません
+  </div>
 
 <% end %>


### PR DESCRIPTION
## 概要
検索UIを改善し、検索条件・並び替えを使いやすいレイアウトへ変更

## 変更内容
- 検索フォームをカードレイアウトへ変更
- タイトル・カテゴリ・記録日の検索項目を整理
- 検索ボタンのデザイン調整
- 並び替えリンクをボタン風UIへ変更
- 一覧表示をカードデザインに統一
- 空データ時の表示を改善

## 確認方法
- localhost:3000/decisions にアクセス
- タイトル・カテゴリ・記録日で検索できること
- 作成日・記録日・タイトルで並び替えできること
- 検索UIが崩れていないこと
- 一覧表示がカード形式になっていること

## 関連Issue
Closes #139 