### PR TITLE
Flashメッセージ改善

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -165,15 +165,7 @@
 
         <% end %>
 
-            <% flash.each do |type, message| %>
-
-              <div class="alert alert-<%= type == "notice" ? "success" : "danger" %>">
-
-                <%= message %>
-
-              </div>
-
-            <% end %>
+         <%= render "shared/flash_messages" %>
 
             <%= yield %>
 

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,19 @@
+<% flash.each do |type, message| %>
+
+  <div
+    class="alert alert-<%= type == "notice" ? "success" : "danger" %> alert-dismissible fade show shadow-sm mb-4"
+    role="alert">
+
+    <%= type == "notice" ? "✅" : "⚠️" %>
+    <%= message %>
+
+    <button
+      type="button"
+      class="btn-close"
+      data-bs-dismiss="alert"
+      aria-label="Close">
+    </button>
+
+  </div>
+
+<% end %>


### PR DESCRIPTION
## 概要
Flashメッセージの表示を改善

## 変更内容
- Flashメッセージを共通パーシャル（`shared/_flash_messages`）へ切り出し
- Bootstrapのdismissible alert（閉じるボタン付き）に変更
- 成功・エラーメッセージのデザインを統一
- `application.html.erb`から共通パーシャルを呼び出すように変更

## 確認方法
- 作成・更新・削除後にFlashメッセージが表示されること
- 「×」ボタンでFlashメッセージを閉じられること
- 成功時は緑、エラー時は赤で表示されること

## 関連Issue
Closes #142 