### PR TITLE
empty State作成

### DIFF
--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -1,10 +1,12 @@
 <h1 class="mb-4">意思決定一覧</h1>
 
-<div class="d-flex justify-content-end mb-3">
-  <%= link_to "＋ 新規作成",
-      new_decision_path,
-      class: "btn btn-primary" %>
-</div>
+<% if @decisions.any? %>
+  <div class="d-flex justify-content-end mb-3">
+    <%= link_to "＋ 新規作成",
+          new_decision_path,
+          class: "btn btn-primary" %>
+  </div>
+<% end %>
 
 <div class="card shadow-sm mb-3">
   <div class="card-body">
@@ -99,8 +101,21 @@
 
 <% else %>
 
-  <div class="alert alert-light text-center">
-    まだ意思決定がありません
-  </div>
+  <div class="text-center py-5">
 
+    <div class="display-1 mb-3">
+      📝
+    </div>
+
+    <h4>まだ意思決定がありません</h4>
+
+    <p class="text-muted mb-4">
+      最初の意思決定を記録してみましょう。
+    </p>
+
+    <%= link_to "＋ 新規作成",
+          new_decision_path,
+          class: "btn btn-primary" %>
+
+  </div>
 <% end %>


### PR DESCRIPTION
## 概要
意思決定一覧画面にEmpty Stateを追加

## 変更内容
- 意思決定が0件の場合のEmpty Stateを追加
- アイコン・説明文・新規作成ボタンを表示
- データ有無に応じて表示を切り替えるよう修正

## 確認方法
- 意思決定が0件の状態で `localhost:3000/decisions` にアクセス
- Empty State（アイコン・説明文・新規作成ボタン）が表示されることを確認
- 意思決定を1件以上登録すると通常の一覧画面が表示されることを確認

## 関連Issue
Closes #143 