### PR TITLE
レスポンシブ調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,32 +76,47 @@
 
             <ul class="dropdown-menu dropdown-menu-end">
 
-              <li class="dropdown-item-text fw-bold">
-                <%= current_user.name %>
-              </li>
+  <li class="dropdown-item-text fw-bold">
+    <%= current_user.name %>
+  </li>
 
-              <li>
-                <hr class="dropdown-divider">
-              </li>
+  <li class="d-md-none">
+    <hr class="dropdown-divider">
+  </li>
 
-              <li>
-                <%= link_to "プロフィール編集",
-                      edit_user_registration_path,
-                      class: "dropdown-item",
-                      data: { turbo: false } %>
-              </li>
+  <li class="d-md-none">
+    <%= link_to "ダッシュボード",
+          dashboard_path,
+          class: "dropdown-item" %>
+  </li>
 
-              <li>
-                <%= link_to "ログアウト",
-                      destroy_user_session_path,
-                      class: "dropdown-item text-danger",
-                      data: {
-                        turbo_method: :delete,
-                        turbo_confirm: "ログアウトしますか？"
-                      } %>
-              </li>
+  <li class="d-md-none">
+    <%= link_to "意思決定一覧",
+          decisions_path,
+          class: "dropdown-item" %>
+  </li>
 
-            </ul>
+  <li>
+    <hr class="dropdown-divider">
+  </li>
+
+  <li>
+    <%= link_to "プロフィール編集",
+          edit_user_registration_path,
+          class: "dropdown-item" %>
+  </li>
+
+  <li>
+    <%= link_to "ログアウト",
+          destroy_user_session_path,
+          class: "dropdown-item text-danger",
+          data: {
+            turbo_method: :delete,
+            turbo_confirm: "ログアウトしますか？"
+          } %>
+  </li>
+
+</ul>
 
           </div>
 
@@ -131,7 +146,7 @@
 
         <% if user_signed_in? %>
 
-          <aside class="col-md-3 col-lg-2 bg-light min-vh-100 border-end p-3">
+          <aside class="d-none d-md-block col-md-3 col-lg-2 bg-light min-vh-100 border-end p-3">
 
             <ul class="nav flex-column">
 
@@ -157,7 +172,7 @@
 
           </aside>
 
-          <main class="col-md-9 col-lg-10 p-4">
+          <main class="col-12 col-md-9 col-lg-10 p-3 p-lg-4">
 
         <% else %>
 


### PR DESCRIPTION
## 概要
レスポンシブ表示時のナビゲーションを改善

## 変更内容
- スマートフォン表示時にサイドバーを非表示に変更
- スマートフォン表示時のみプロフィールメニューに「ダッシュボード」「意思決定一覧」を追加
- レスポンシブ時でも画面全体が見やすくなるようレイアウトを調整

## 確認方法
- `localhost:3000` にアクセス
- PC表示ではサイドバーが表示されることを確認
- スマートフォン表示ではサイドバーが非表示になることを確認
- スマートフォン表示でプロフィールメニューから「ダッシュボード」「意思決定一覧」に遷移できることを確認

## 関連Issue
Closes #144 