### PR TITLE
loading改善

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,5 +1,7 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
 import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+import LoadingController from "controllers/loading_controller"
+application.register("loading", LoadingController)
 
 eagerLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit() {
+    const button = this.element.querySelector("input[type='submit']")
+
+    if (!button) return
+
+    button.disabled = true
+    button.value = button.dataset.loadingText || "処理中..."
+  }
+}

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -21,7 +21,8 @@
 <%= form_with model: @decision,
       local: true,
       data: {
-        controller: "decision-form decision-preview"
+        controller: "decision-preview loading",
+        action: "submit->loading#submit"
       } do |f| %>
 
   <div class="mb-3">
@@ -202,7 +203,8 @@
   <div class="mt-4">
 
     <%= f.submit "更新する",
-          class: "btn btn-primary w-100" %>
+          class: "btn btn-primary w-100",
+          data: { loading_text: "更新中..." } %>
 
   </div>
 

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -38,7 +38,8 @@
 <%= form_with model: @decision,
       local: true,
       data: {
-        controller: "decision-preview"
+        controller: "decision-preview loading",
+        action: "submit->loading#submit"
       } do |f| %>
 
   <div class="mb-3">
@@ -78,7 +79,6 @@
 
     <%= hidden_field_tag "decision[options_attributes][#{index}][id]", option.id %>
 
-    <!-- ★これ超重要 -->
     <%= hidden_field_tag "decision[options_attributes][#{index}][_destroy]", "0", class: "destroy-flag" %>
 
   </div>
@@ -122,7 +122,8 @@
 
   <div class="mt-4">
     <%= f.submit "作成する",
-          class: "btn btn-primary w-100" %>
+          class: "btn btn-primary w-100",
+          data: { loading_text: "作成中..." } %>
   </div>
 
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,11 @@
 
 <%= form_for(resource,
       as: resource_name,
-      url: registration_path(resource_name)) do |f| %>
+      url: registration_path(resource_name),
+      data: {
+        controller: "loading",
+        action: "submit->loading#submit"
+      }) do |f| %>
 
   <%= render "devise/shared/error_messages", resource: resource %>
 
@@ -41,7 +45,8 @@
   </div>
 
   <div class="d-grid">
-    <%= f.submit "登録", class: "btn btn-primary" %>
+    <%= f.submit "新規登録", class: "btn btn-primary",
+    data: { loading_text: "登録中..." } %>
   </div>
 
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,11 @@
 
 <%= form_for(resource,
       as: resource_name,
-      url: session_path(resource_name)) do |f| %>
+      url: session_path(resource_name),
+      data: {
+        controller: "loading",
+        action: "submit->loading#submit"
+      }) do |f| %>
 
   <!-- メール -->
   <div class="mb-3">
@@ -44,7 +48,8 @@
   <!-- submit -->
   <div class="d-grid">
     <%= f.submit "ログイン",
-          class: "btn btn-primary" %>
+          class: "btn btn-primary",
+          data: { loading_text: "ログイン中..." } %>
   </div>
 
 <% end %>


### PR DESCRIPTION
## 概要
フォーム送信時のローディング表示を追加し、二重送信を防止しました。

## 変更内容
* Stimulusで`loading_controller`を追加
* フォーム送信時に送信ボタンを無効化
* ボタン文言を「作成中...」「更新中...」「ログイン中...」「登録中...」へ変更
* 新規作成・編集・ログイン・新規登録画面にローディング処理を適用

## 確認方法
* 新規作成画面で送信ボタンを押し、「作成中...」と表示されること
* 編集画面で送信ボタンを押し、「更新中...」と表示されること
* ログイン画面で送信ボタンを押し、「ログイン中...」と表示されること
* 新規登録画面で送信ボタンを押し、「登録中...」と表示されること
* 送信後、ボタンが無効化され二重送信できないこと

## 関連Issue
Closes #145 
