### PR TITLE
一覧画面改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "jbuilder"
 
 gem "resend"
 
+gem "kaminari"
+
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -404,6 +416,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  kaminari
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,3 +25,23 @@
 .btn-outline-dark {
   min-width: 110px;
 }
+
+.pagination {
+  margin-bottom: 0;
+}
+
+.pagination .page-link {
+  color: #0d6efd;
+  border-radius: 8px;
+  margin: 0 4px;
+}
+
+.pagination .page-item.active .page-link {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.pagination .page-link:hover {
+  background-color: #e9f2ff;
+}

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -8,13 +8,15 @@ class DecisionsController < ApplicationController
 
     @q.sorts = "created_at desc" if @q.sorts.empty?
 
-    @decisions = @q.result(distinct: true)
+    @decisions = @q
+      .result(distinct: true)
+      .page(params[:page])
+      .per(3)
   end
 
   def show
     @decision = current_user.decisions.find(params[:id]).reload
   end
-
 
   def new
     @decision = Decision.new

--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -38,10 +38,16 @@
                 class: "form-control" %>
         </div>
 
-        <div class="col-12 col-lg-2 d-grid">
-          <%= f.submit "検索",
-                class: "btn btn-primary" %>
-        </div>
+        <div class="col-12 col-lg-2">
+  <div class="d-grid gap-2">
+    <%= f.submit "検索",
+          class: "btn btn-primary" %>
+
+    <%= link_to "クリア",
+          decisions_path,
+          class: "btn btn-outline-secondary" %>
+  </div>
+</div>
 
       </div>
 
@@ -63,6 +69,18 @@
     </div>
 
   </div>
+</div>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <p class="text-muted mb-0">
+    <strong><%= @decisions.count %></strong> 件の意思決定
+  </p>
+
+  <% if params[:q].present? %>
+    <%= link_to "検索条件をクリア",
+          decisions_path,
+          class: "btn btn-outline-secondary btn-sm" %>
+  <% end %>
 </div>
 
 <% if @decisions.any? %>
@@ -98,6 +116,14 @@
     </div>
 
   <% end %>
+
+ <div class="d-flex justify-content-between align-items-center mb-3">
+  <p class="text-muted mb-0">
+    全 <strong><%= @decisions.total_count %></strong> 件
+  </p>
+
+  <%= paginate @decisions %>
+</div>
 
 <% else %>
 

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,9 @@
+<% if current_page.last? %>
+  <li class="page-item disabled">
+    <span class="page-link">次へ →</span>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to "次へ →", url, rel: "next", class: "page-link" %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,9 @@
+<% if current_page.first? %>
+  <li class="page-item disabled">
+    <span class="page-link">← 前へ</span>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to "← 前へ", url, rel: "prev", class: "page-link" %>
+  </li>
+<% end %>


### PR DESCRIPTION
## 概要

意思決定一覧画面にページネーション機能を追加しました。

## 変更内容

* Kaminariを導入
* 意思決定一覧にページネーションを実装
* ページネーションのレイアウトを調整

## 確認方法

* 意思決定を11件以上作成する
* `/decisions` にアクセスする
* 一覧の下部にページネーションが表示されること
* 「前へ」「次へ」およびページ番号からページ遷移できること

## 関連Issue

Closes #146 
