### PR TITLE
Stimulus導入整理

### DIFF
--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,7 +1,5 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
 import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
-import LoadingController from "controllers/loading_controller"
-application.register("loading", LoadingController)
 
 eagerLoadControllersFrom("controllers", application)


### PR DESCRIPTION
## 概要
Stimulusの導入設定を整理

## 変更内容
- Stimulus Controllerの登録方法を整理
- `eagerLoadControllersFrom` による自動読み込みへ統一
- 不要な手動登録を削除

## 確認方法
- localhost:3000 にアクセス
- Stimulus Controllerが正常に動作することを確認

## 関連Issue
Closes #178 