### PR TITLE
Add category suggestions

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,10 @@
+class CategoriesController < ApplicationController
+  def search
+    categories = Category.where(
+      "name LIKE ?",
+      "%#{params[:keyword]}%"
+    )
+
+    render json: categories
+  end
+end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/javascript/controllers/category_suggestions_controller.js
+++ b/app/javascript/controllers/category_suggestions_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "hidden"]
+
+  select() {
+    const value = this.inputTarget.value
+
+    const option = this.categories.find(
+      category => category.name === value
+    )
+
+    if (option) {
+      this.hiddenTarget.value = option.id
+    }
+  }
+
+  connect() {
+    this.categories = JSON.parse(
+      this.element.dataset.categories
+    )
+  }
+}

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -52,15 +52,37 @@
     <%= f.date_field :recorded_on, class: "form-control" %>
   </div>
 
-  <div class="mb-4">
-    <%= f.label :category_id, "カテゴリ", class: "form-label" %>
-    <%= f.collection_select :category_id,
-          Category.all,
-          :id,
-          :name,
-          { prompt: "選択してください" },
-          class: "form-select" %>
-  </div>
+  <div class="mb-4"
+     data-controller="category-suggestions"
+     data-categories="<%= Category.all.to_json %>">
+
+  <%= f.label :category_id, "カテゴリ", class: "form-label" %>
+
+  <%= text_field_tag :category_name,
+        @decision.category&.name,
+        list: "category-list",
+        class: "form-control",
+        placeholder: "カテゴリを入力または選択",
+        data: {
+          category_suggestions_target: "input",
+          action: "change->category-suggestions#select"
+        } %>
+
+  <datalist id="category-list">
+    <% Category.all.each do |category| %>
+      <option value="<%= category.name %>">
+    <% end %>
+  </datalist>
+
+  <%= f.hidden_field :category_id,
+        value: @decision.category_id,
+        data: {
+          category_suggestions_target: "hidden"
+        } %>
+
+</div>
+
+
 
   <hr>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,12 @@ Rails.application.routes.draw do
     resources :options, only: [:create]
   end
 
+  resources :categories do
+  collection do
+    get :search
+  end
+end
+
   get "up" => "rails/health#show", as: :rails_health_check
 
 

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
決断作成フォームにカテゴリ候補入力機能を追加

## 変更内容
- カテゴリ選択をプルダウンから入力形式へ変更
- 入力時にカテゴリ候補を表示する機能を追加
- 選択したカテゴリIDを保存できるように対応

## 確認方法
- localhost:3000 にアクセス
- 決断作成画面でカテゴリ入力を確認
- カテゴリ候補を選択して正常に保存できることを確認

## 関連Issue
Closes #179 