### PR TITLE
部分一致検索

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,9 +1,14 @@
 class CategoriesController < ApplicationController
   def search
-    categories = Category.where(
-      "name LIKE ?",
-      "%#{params[:keyword]}%"
-    )
+    categories =
+      if params[:keyword].present?
+        Category.where(
+          "name LIKE ?",
+          "%#{params[:keyword]}%"
+        )
+      else
+        Category.all
+      end
 
     render json: categories
   end

--- a/app/javascript/controllers/category_suggestions_controller.js
+++ b/app/javascript/controllers/category_suggestions_controller.js
@@ -1,23 +1,49 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "hidden"]
-
-  select() {
-    const value = this.inputTarget.value
-
-    const option = this.categories.find(
-      category => category.name === value
-    )
-
-    if (option) {
-      this.hiddenTarget.value = option.id
-    }
-  }
+  static targets = ["input", "list", "hidden"]
 
   connect() {
-    this.categories = JSON.parse(
-      this.element.dataset.categories
-    )
+    document.addEventListener("click", this.close.bind(this))
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.close.bind(this))
+  }
+
+  search() {
+    const keyword = this.inputTarget.value
+
+    fetch(`/categories/search?keyword=${encodeURIComponent(keyword)}`)
+      .then(response => response.json())
+      .then(categories => {
+        this.listTarget.innerHTML = ""
+
+        categories.forEach(category => {
+          const button = document.createElement("button")
+
+          button.type = "button"
+          button.className =
+            "list-group-item list-group-item-action"
+
+          button.textContent = category.name
+
+          button.addEventListener("click", (event) => {
+            event.stopPropagation()
+
+            this.inputTarget.value = category.name
+            this.hiddenTarget.value = category.id
+            this.listTarget.innerHTML = ""
+          })
+
+          this.listTarget.appendChild(button)
+        })
+      })
+  }
+
+  close(event) {
+    if (!this.element.contains(event.target)) {
+      this.listTarget.innerHTML = ""
+    }
   }
 }

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -53,26 +53,22 @@
   </div>
 
   <div class="mb-4"
-     data-controller="category-suggestions"
-     data-categories="<%= Category.all.to_json %>">
+     data-controller="category-suggestions">
 
   <%= f.label :category_id, "カテゴリ", class: "form-label" %>
 
   <%= text_field_tag :category_name,
         @decision.category&.name,
-        list: "category-list",
         class: "form-control",
         placeholder: "カテゴリを入力または選択",
         data: {
           category_suggestions_target: "input",
-          action: "change->category-suggestions#select"
+          action: "focus->category-suggestions#search input->category-suggestions#search"
         } %>
 
-  <datalist id="category-list">
-    <% Category.all.each do |category| %>
-      <option value="<%= category.name %>">
-    <% end %>
-  </datalist>
+  <div class="list-group mt-2"
+       data-category-suggestions-target="list">
+  </div>
 
   <%= f.hidden_field :category_id,
         value: @decision.category_id,


### PR DESCRIPTION
## 概要
カテゴリ入力フォームに部分一致検索機能を追加

## 変更内容
- カテゴリ入力時にDBから部分一致検索を実行する機能を追加
- 入力欄クリック時にカテゴリ一覧を候補表示する機能を追加
- 候補一覧を外部クリックで閉じるように対応

## 確認方法
- localhost:3000 にアクセス
- 決断作成画面を開く
- カテゴリ入力欄をクリックして既存カテゴリ一覧が表示されることを確認
- 文字を入力して部分一致検索が動作することを確認
- 候補を選択してカテゴリが保存されることを確認

## 関連Issue
Closes #180 