### PR TITLE
タイムラインUI作成

### DIFF
--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -1,0 +1,34 @@
+.timeline {
+  position: relative;
+  margin-left: 20px;
+  padding-left: 30px;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 7px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #dee2e6;
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 30px;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1px;
+  top: 20px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #0d6efd;
+}
+
+.timeline-item .card {
+  margin-left: 25px;
+}

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -23,6 +23,14 @@ class DecisionsController < ApplicationController
     3.times { @decision.options.build }
   end
 
+  def timeline
+  @decisions = current_user.decisions
+                           .includes(:category)
+                           .order(recorded_on: :desc)
+end
+
+
+
 def create
   @decision = current_user.decisions.new(decision_params)
 

--- a/app/views/decisions/timeline.html.erb
+++ b/app/views/decisions/timeline.html.erb
@@ -1,0 +1,44 @@
+<h1 class="mb-4">タイムライン</h1>
+
+<div class="timeline">
+
+  <% @decisions.each do |decision| %>
+
+    <div class="timeline-item">
+
+      <div class="timeline-dot"></div>
+
+      <%= link_to decision,
+            class: "card text-decoration-none text-dark shadow-sm" do %>
+
+        <div class="card-body">
+
+          <small class="text-muted">
+            <%= (decision.recorded_on || decision.created_at).strftime("%Y/%m/%d") %>
+          </small>
+
+          <h5 class="mt-2">
+            <%= decision.title %>
+          </h5>
+
+          <% if decision.category.present? %>
+            <span class="badge bg-primary">
+              <%= decision.category.name %>
+            </span>
+          <% end %>
+
+          <% if decision.reason.present? %>
+            <p class="mt-3 mb-0">
+              <%= truncate(decision.reason, length: 80) %>
+            </p>
+          <% end %>
+
+        </div>
+
+      <% end %>
+
+    </div>
+
+  <% end %>
+
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -37,6 +37,10 @@
 
 </div>
 
+<%= link_to "タイムラインを見る",
+      timeline_decisions_path,
+      class: "btn btn-outline-primary w-100 my-3" %>
+
 <% @decisions.limit(5).each do |decision| %>
 
   <%= link_to decision_path(decision),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -168,6 +168,10 @@
 
               </li>
 
+             <%= link_to "タイムライン",
+      timeline_decisions_path,
+      class: "nav-link w-100" %>
+
             </ul>
 
           </aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,15 +17,21 @@ Rails.application.routes.draw do
 
   get "dashboard", to: "home#index"
 
-  resources :decisions do
-    resources :options, only: [:create]
+resources :decisions do
+  collection do
+    get :timeline
   end
 
-  resources :categories do
+  resources :options, only: [:create]
+end
+
+resources :categories do
   collection do
     get :search
   end
 end
+
+
 
   get "up" => "rails/health#show", as: :rails_health_check
 


### PR DESCRIPTION
## 概要
意思決定を時系列で振り返るためのタイムライン画面を追加

## 変更内容
- タイムライン画面を新規作成
- `timeline` アクションとルーティングを追加
- 意思決定を日付順で表示するUIを実装
- ホーム画面からタイムライン画面へ遷移できるように導線を追加

## 確認方法
- localhost:3000 にアクセス
- ホーム画面の「タイムラインを見る」をクリック
- タイムライン画面が表示されることを確認
- 意思決定が日付順に表示されることを確認
- 各意思決定をクリックすると詳細画面へ遷移することを確認

## 関連Issue
Closes #147 