### PR TITLE
日付順表示

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -45,3 +45,14 @@
 .pagination .page-link:hover {
   background-color: #e9f2ff;
 }
+
+.timeline-date {
+  width: 70px;
+  text-align: center;
+}
+
+.timeline-item {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 30px;
+}

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -26,7 +26,7 @@ class DecisionsController < ApplicationController
   def timeline
   @decisions = current_user.decisions
                            .includes(:category)
-                           .order(recorded_on: :desc)
+                           .order(recorded_on: :desc, created_at: :desc)
 end
 
 

--- a/app/views/decisions/timeline.html.erb
+++ b/app/views/decisions/timeline.html.erb
@@ -2,19 +2,31 @@
 
 <div class="timeline">
 
+  <% current_month = nil %>
+
   <% @decisions.each do |decision| %>
+
+    <% date = decision.recorded_on || decision.created_at.to_date %>
+
+    <% if current_month != date.strftime("%Y年%m月") %>
+      <% current_month = date.strftime("%Y年%m月") %>
+
+      <h4 class="mt-4 mb-3">
+        <%= current_month %>
+      </h4>
+    <% end %>
 
     <div class="timeline-item">
 
       <div class="timeline-dot"></div>
 
       <%= link_to decision,
-            class: "card text-decoration-none text-dark shadow-sm" do %>
+            class: "card text-decoration-none text-dark shadow-sm w-100" do %>
 
         <div class="card-body">
 
           <small class="text-muted">
-            <%= (decision.recorded_on || decision.created_at).strftime("%Y/%m/%d") %>
+            <%= date.strftime("%m/%d") %>
           </small>
 
           <h5 class="mt-2">


### PR DESCRIPTION
## 概要
タイムラインを日付順に表示するよう改善

## 変更内容
- タイムラインの表示順を日付の新しい順に変更
- 年月ごとの見出しを追加し、時系列で見やすいレイアウトに改善
- 日付表示を整理し、タイムラインの視認性を向上

## 確認方法
- localhost:3000 にアクセス
- タイムライン画面を開く
- 意思決定が日付の新しい順に表示されることを確認
- 年月ごとに見出しが表示されることを確認
- 各意思決定のタイトル・カテゴリ・日付が正しく表示されることを確認

## 関連Issue
Closes #148 