### PR TITLE
感情検索追加

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -9,9 +9,10 @@ class DecisionsController < ApplicationController
     @q.sorts = "created_at desc" if @q.sorts.empty?
 
     @decisions = @q
-      .result(distinct: true)
-      .page(params[:page])
-      .per(3)
+  .result(distinct: true)
+  .includes(:category, :emotion_types)
+  .page(params[:page])
+  .per(3)
   end
 
   def show

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -37,7 +37,7 @@ class Decision < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    ["category"]
+    ["category", "decision_emotions", "emotion_types"]
   end
 
   def clear_selected_option_if_destroyed

--- a/app/models/decision_emotion.rb
+++ b/app/models/decision_emotion.rb
@@ -1,4 +1,12 @@
 class DecisionEmotion < ApplicationRecord
   belongs_to :decision
   belongs_to :emotion_type
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "decision_id", "emotion_type_id", "id", "updated_at"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["decision", "emotion_type"]
+  end
 end

--- a/app/views/decisions/index.html.erb
+++ b/app/views/decisions/index.html.erb
@@ -33,6 +33,17 @@
         </div>
 
         <div class="col-12 col-lg-3">
+  <%= f.label :decision_emotions_emotion_type_id_eq, "感情", class: "form-label" %>
+
+  <%= f.collection_select :decision_emotions_emotion_type_id_eq,
+        EmotionType.all,
+        :id,
+        :name,
+        { include_blank: "すべて" },
+        { class: "form-select" } %>
+</div>
+
+        <div class="col-12 col-lg-3">
   <%= f.label :recorded_on_gteq, "開始日", class: "form-label" %>
   <%= f.date_field :recorded_on_gteq, class: "form-control" %>
 </div>
@@ -112,9 +123,21 @@
 
         </div>
 
-        <span class="badge bg-secondary">
-          <%= decision.category&.name || "未設定" %>
-        </span>
+        <div class="d-flex flex-wrap gap-2 mt-2">
+  <span class="badge bg-secondary">
+    <%= decision.category&.name || "未設定" %>
+  </span>
+
+  <% decision.emotion_types.each do |emotion| %>
+    <span class="badge bg-warning text-dark">
+      <%= emotion.name %>
+    </span>
+  <% end %>
+</div>
+
+
+
+
 
       </div>
     </div>


### PR DESCRIPTION
## 概要
意思決定一覧に感情検索機能を追加し、一覧カードに感情を表示

## 変更内容
- 感情による検索機能を追加
- 一覧カードに登録済みの感情をバッジで表示
- Ransackの検索対象に `DecisionEmotion` と `EmotionType` を追加

## 確認方法
- `localhost:3000/decisions` にアクセス
- 感情を選択して検索し、該当する意思決定のみ表示されることを確認
- 一覧カードにカテゴリと感情のバッジが表示されることを確認
- タイトル・カテゴリ・期間・感情を組み合わせて検索できることを確認

## 関連Issue
Closes #182 