### PR TITLE
感情データ集計

### DIFF
--- a/app/controllers/emotion_analysis_controller.rb
+++ b/app/controllers/emotion_analysis_controller.rb
@@ -6,5 +6,8 @@ class EmotionAnalysisController < ApplicationController
                                   .joins(:emotion_types)
                                   .group("emotion_types.name")
                                   .count
+
+    @total_emotions = @emotion_counts.values.sum
+    @most_emotion = @emotion_counts.max_by { |_, count| count }
   end
 end

--- a/app/views/emotion_analysis/index.html.erb
+++ b/app/views/emotion_analysis/index.html.erb
@@ -2,13 +2,36 @@
 
 <% if @emotion_counts.present? %>
 
-  <div class="card shadow-sm">
+  <div class="card shadow-sm mb-4">
     <div class="card-body">
       <h4 class="mb-3">感情の割合</h4>
 
       <%= pie_chart @emotion_counts,
             donut: true,
             height: "400px" %>
+    </div>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h4 class="mb-3">感情データ集計</h4>
+
+      <table class="table table-striped mb-0">
+        <thead>
+          <tr>
+            <th>感情</th>
+            <th class="text-end">件数</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @emotion_counts.each do |emotion, count| %>
+            <tr>
+              <td><%= emotion %></td>
+              <td class="text-end"><%= count %> 件</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要
感情分析ページに感情データの集計機能を追加

## 変更内容
- EmotionAnalysisControllerで感情データを集計
- EmotionTypeごとの件数を取得
- 感情総数を取得
- 最も多い感情を取得
- 感情分析ページに円グラフを表示

## 確認方法
- `/emotion_analysis` にアクセス
- 円グラフが表示されること
- 感情ごとの件数が正しく集計されること
- 総感情数・最多感情が正しく表示されること

## 関連Issue
Closes #152 