### PR TITLE
月別感情グラフ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,5 @@ gem "devise", "~> 5.0"
 gem "ransack", "~> 4.4"
 
 gem "chartkick"
+
+gem "groupdate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    groupdate (6.7.0)
+      activesupport (>= 7.1)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -414,6 +416,7 @@ DEPENDENCIES
   chartkick
   debug
   devise (~> 5.0)
+  groupdate
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/app/controllers/emotion_analysis_controller.rb
+++ b/app/controllers/emotion_analysis_controller.rb
@@ -9,5 +9,11 @@ class EmotionAnalysisController < ApplicationController
 
     @total_emotions = @emotion_counts.values.sum
     @most_emotion = @emotion_counts.max_by { |_, count| count }
+
+    @monthly_emotions = current_user.decisions
+                                    .joins(:emotion_types)
+                                    .where.not(recorded_on: nil)
+                                    .group_by_month(:recorded_on, format: "%Y-%m")
+                                    .count
   end
 end

--- a/app/views/emotion_analysis/index.html.erb
+++ b/app/views/emotion_analysis/index.html.erb
@@ -2,6 +2,35 @@
 
 <% if @emotion_counts.present? %>
 
+  <div class="row mb-4">
+
+    <div class="col-md-6">
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h6 class="text-muted">総感情数</h6>
+          <h2><%= @total_emotions %></h2>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-6">
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h6 class="text-muted">最も多い感情</h6>
+
+          <% if @most_emotion.present? %>
+            <h2>
+              <%= @most_emotion.first %>
+              (<%= @most_emotion.last %>件)
+            </h2>
+          <% end %>
+
+        </div>
+      </div>
+    </div>
+
+  </div>
+
   <div class="card shadow-sm mb-4">
     <div class="card-body">
       <h4 class="mb-3">感情の割合</h4>
@@ -12,7 +41,7 @@
     </div>
   </div>
 
-  <div class="card shadow-sm">
+  <div class="card shadow-sm mb-4">
     <div class="card-body">
       <h4 class="mb-3">感情データ集計</h4>
 
@@ -23,6 +52,7 @@
             <th class="text-end">件数</th>
           </tr>
         </thead>
+
         <tbody>
           <% @emotion_counts.each do |emotion, count| %>
             <tr>
@@ -31,7 +61,17 @@
             </tr>
           <% end %>
         </tbody>
+
       </table>
+    </div>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h4 class="mb-3">月別の感情数</h4>
+
+      <%= column_chart @monthly_emotions,
+            height: "350px" %>
     </div>
   </div>
 


### PR DESCRIPTION
## 概要
感情分析ページに感情データ集計機能と月別感情グラフを追加

## 変更内容
- EmotionAnalysisControllerで感情データを集計
- 感情ごとの件数を円グラフで表示
- 総感情数・最も多い感情を表示
- 感情データ集計テーブルを追加
- 月別感情数を棒グラフで表示

## 確認方法
- `/emotion_analysis` にアクセス
- 円グラフが表示されること
- 総感情数・最も多い感情が表示されること
- 感情ごとの件数がテーブルに表示されること
- 月別感情数の棒グラフが表示されること

## 関連Issue
Closes #153 