### PR TITLE
ダッシュボード表示

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,14 +2,15 @@ class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @decisions =
-      current_user.decisions
-                  .order(Arel.sql("COALESCE(recorded_on, created_at) DESC"))
+    @decisions = current_user.decisions
+                             .order(Arel.sql("COALESCE(recorded_on, created_at) DESC"))
 
-    @emotion_chart =
-      current_user.decisions
-                  .joins(:emotion_types)
-                  .group("emotion_types.name")
-                  .count
+    @emotion_chart = current_user.decisions
+                                 .joins(:emotion_types)
+                                 .group("emotion_types.name")
+                                 .count
+
+    @decision_count = current_user.decisions.count
+    @most_emotion = @emotion_chart.max_by { |_, count| count }
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -25,6 +25,48 @@
         class: "btn btn-primary w-100" %>
 </div>
 
+<div class="row g-3 mb-4">
+
+  <div class="col-md-6">
+    <div class="card text-center shadow-sm">
+      <div class="card-body">
+        <h6 class="text-muted">意思決定数</h6>
+        <h2><%= @decision_count %></h2>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <div class="card text-center shadow-sm">
+      <div class="card-body">
+        <h6 class="text-muted">最も多い感情</h6>
+        <h2><%= @most_emotion&.first || "なし" %></h2>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="card shadow-sm mb-4">
+  <div class="card-body">
+    <h5 class="mb-3">感情の割合</h5>
+
+    <% if @emotion_chart.present? %>
+      <%= pie_chart @emotion_chart,
+            donut: true,
+            height: "280px" %>
+    <% else %>
+      <p class="text-muted mb-0">感情データがありません。</p>
+    <% end %>
+  </div>
+</div>
+
+<div class="text-end mb-4">
+  <%= link_to "感情分析を見る →",
+        emotion_analysis_path,
+        class: "btn btn-outline-primary" %>
+</div>
+
 <hr>
 
 <div class="mb-3 d-flex justify-content-between align-items-center">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -49,7 +49,7 @@
 
 <div class="card shadow-sm mb-4">
   <div class="card-body">
-    <h5 class="mb-3">感情の割合</h5>
+    <h5 class="mb-3">割合</h5>
 
     <% if @emotion_chart.present? %>
       <%= pie_chart @emotion_chart,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,7 +103,7 @@
   </li>
 
 <li class="d-md-none">
-  <%= link_to "感情分析", emotion_analysis_path, class: "nav-link" %>
+  <%= link_to "感情分析", emotion_analysis_path, class: "dropdown-item" %>
 </li>
 
   <li>
@@ -182,7 +182,7 @@
       timeline_decisions_path,
       class: "nav-link w-100" %>
 
-      <%= link_to "感情分析", emotion_analysis_path, class: "nav-link" %>
+     <%= link_to "感情分析", emotion_analysis_path, class: "nav-link w-100" %>
 
             </ul>
 


### PR DESCRIPTION
## 概要
ダッシュボード画面を作成し、感情データの集計結果を表示できるようにしました。

## 変更内容
- ダッシュボード画面追加
- 感情サマリー表示機能追加
- 感情データの統計表示追加
- ダッシュボード用のビュー・コントローラー設定

## 確認方法
- localhost:3000 にアクセス
- ダッシュボード画面で感情データの集計結果が表示されることを確認

## 関連Issue
Closes #154 