### PR TITLE
カテゴリ別感情分析

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -1,6 +1,6 @@
 class DecisionsController < ApplicationController
-  after_action :verify_authorized, except: %i[index timeline]
-  after_action :verify_policy_scoped, only: %i[index timeline]
+  after_action :verify_authorized, except: %i[index timeline analysis]
+  after_action :verify_policy_scoped, only: %i[index timeline analysis]
 
   before_action :authenticate_user!
   before_action :set_decision, only: %i[show edit update destroy]
@@ -32,6 +32,22 @@ class DecisionsController < ApplicationController
                    .includes(:category)
                    .order(recorded_on: :desc, created_at: :desc)
   end
+
+def analysis
+  @category_emotions =
+    policy_scope(Decision)
+      .joins(:category, :decision_emotions, :emotion_types)
+      .group("categories.name", "emotion_types.name")
+      .count
+
+  @chart_data =
+    @category_emotions.map do |(category, emotion), count|
+      [
+        "#{category}（#{emotion}）",
+        count
+      ]
+    end
+end
 
   def create
     @decision = current_user.decisions.new(decision_params)

--- a/app/views/decisions/analysis.html.erb
+++ b/app/views/decisions/analysis.html.erb
@@ -1,0 +1,36 @@
+<h2 class="mb-4">カテゴリ別感情分析</h2>
+
+<div class="card shadow-sm mb-4">
+  <div class="card-body">
+
+    <%= column_chart @chart_data,
+          stacked: true,
+          height: "400px" %>
+
+  </div>
+</div>
+
+
+<h3 class="mb-3">詳細データ</h3>
+
+<table class="table table-bordered">
+
+  <thead class="table-light">
+    <tr>
+      <th>カテゴリ</th>
+      <th>感情</th>
+      <th>件数</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @category_emotions.each do |(category, emotion), count| %>
+      <tr>
+        <td><%= category %></td>
+        <td><%= emotion %></td>
+        <td><%= count %> 件</td>
+      </tr>
+    <% end %>
+  </tbody>
+
+</table>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -63,7 +63,7 @@
 
 <div class="text-end mb-4">
   <%= link_to "感情分析を見る →",
-        emotion_analysis_path,
+         analysis_decisions_path,
         class: "btn btn-outline-primary" %>
 </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,7 +103,7 @@
   </li>
 
 <li class="d-md-none">
-  <%= link_to "感情分析", emotion_analysis_path, class: "dropdown-item" %>
+  <%= link_to "感情分析", analysis_decisions_path, class: "dropdown-item" %>
 </li>
 
   <li>
@@ -182,7 +182,7 @@
       timeline_decisions_path,
       class: "nav-link w-100" %>
 
-     <%= link_to "感情分析", emotion_analysis_path, class: "nav-link w-100" %>
+     <%= link_to "感情分析", analysis_decisions_path, class: "nav-link w-100" %>
 
             </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get "emotion_analysis/index"
-
   devise_for :users, controllers: {
     registrations: "users/registrations",
     passwords: "users/passwords"
@@ -18,25 +16,22 @@ Rails.application.routes.draw do
 
   get "dashboard", to: "home#index"
 
-resources :decisions do
-  collection do
-    get :timeline
+  resources :decisions do
+    collection do
+      get :timeline
+      get :analysis
+    end
+
+    resources :options, only: [:create]
   end
 
-  resources :options, only: [:create]
-end
-
-resources :categories do
-  collection do
-    get :search
+  resources :categories do
+    collection do
+      get :search
+    end
   end
-end
-
-
 
   get "up" => "rails/health#show", as: :rails_health_check
-
-  get "emotion_analysis", to: "emotion_analysis#index"
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 概要
カテゴリ別の感情分析機能を追加

## 変更内容
- 意思決定データからカテゴリ別・感情別の集計処理を追加
- 感情分析ページにカテゴリ別感情一覧を表示
- Chartkickを使用したグラフ表示を追加
- 感情分析ページへのリンクを追加

## 確認方法
1. ログインする
2. ダッシュボードまたはサイドメニューから「感情分析」を開く
3. カテゴリ別の感情集計とグラフが表示されることを確認

## 関連Issue
Closes #155 