### PR TITLE
カテゴリ別分析

### DIFF
--- a/app/controllers/decision_pattern_analysis_controller.rb
+++ b/app/controllers/decision_pattern_analysis_controller.rb
@@ -1,0 +1,9 @@
+class DecisionPatternAnalysisController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    analysis = DecisionPatternAnalysisService.new(current_user)
+
+    @category_counts = analysis.category_counts
+  end
+end

--- a/app/helpers/decision_pattern_analysis_helper.rb
+++ b/app/helpers/decision_pattern_analysis_helper.rb
@@ -1,0 +1,2 @@
+module DecisionPatternAnalysisHelper
+end

--- a/app/services/decision_pattern_analysis_service.rb
+++ b/app/services/decision_pattern_analysis_service.rb
@@ -1,0 +1,18 @@
+class DecisionPatternAnalysisService
+  def initialize(user)
+    @user = user
+  end
+
+  def category_counts
+    decisions
+      .joins(:category)
+      .group("categories.name")
+      .count
+  end
+
+  private
+
+  def decisions
+    @user.decisions
+  end
+end

--- a/app/views/decision_pattern_analysis/index.html.erb
+++ b/app/views/decision_pattern_analysis/index.html.erb
@@ -1,0 +1,3 @@
+<h1>意思決定パターン分析</h1>
+
+<%= column_chart @category_counts %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -102,6 +102,12 @@
           class: "dropdown-item" %>
   </li>
 
+  <li class="d-md-none">
+    <%= link_to "意思決定パターン分析",
+          decision_pattern_analysis_path,
+          class: "dropdown-item" %>
+  </li>
+
 <li class="d-md-none">
   <%= link_to "感情分析", emotion_analysis_path, class: "dropdown-item" %>
 </li>
@@ -181,6 +187,10 @@
              <%= link_to "タイムライン",
       timeline_decisions_path,
       class: "nav-link w-100" %>
+
+      <%= link_to "意思決定パターン分析",
+      decision_pattern_analysis_path,
+      class: "nav-link  w-100" %>
 
      <%= link_to "感情分析", emotion_analysis_path, class: "nav-link w-100" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "decision_pattern_analysis/index"
   devise_for :users, controllers: {
     registrations: "users/registrations",
     passwords: "users/passwords"
@@ -17,6 +18,9 @@ Rails.application.routes.draw do
   get "dashboard", to: "home#index"
 
   get "emotion_analysis", to: "emotion_analysis#index"
+
+  get "decision_pattern_analysis",
+    to: "decision_pattern_analysis#index"
 
   resources :decisions do
     collection do

--- a/test/controllers/decision_pattern_analysis_controller_test.rb
+++ b/test/controllers/decision_pattern_analysis_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DecisionPatternAnalysisControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get decision_pattern_analysis_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
意思パターン分析ページを追加し、カテゴリ別の分析結果を表示できるようにしました。

## 変更内容
- DecisionPatternAnalysisController を追加
- DecisionPatternAnalysisService を追加
- 意思パターン分析画面を追加
- カテゴリ別の意思決定件数を集計・表示
- 月別集計データを表示
- ルーティングとナビゲーションを追加

## 確認方法
- `localhost:3000/decision_pattern_analysis` にアクセス
- カテゴリ別の分析結果が表示されること
- グラフが表示されること
- 月別集計が表示されること

## 関連Issue
Closes #158 