### PR TITLE
意思決定回数分析

### DIFF
--- a/app/controllers/decision_pattern_analysis_controller.rb
+++ b/app/controllers/decision_pattern_analysis_controller.rb
@@ -2,10 +2,11 @@ class DecisionPatternAnalysisController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    analysis = DecisionPatternAnalysisService.new(current_user)
+  analysis = DecisionPatternAnalysisService.new(current_user)
 
-    @category_counts = analysis.category_counts
-    @decision_count = analysis.decision_count
-    @most_category = analysis.most_category
-  end
+  @category_counts = analysis.category_counts
+  @decision_count = analysis.total_decisions
+  @decision_counts = analysis.decision_counts_by_month
+  @most_category = @category_counts.max_by { |_, count| count }
+ end
 end

--- a/app/services/decision_pattern_analysis_service.rb
+++ b/app/services/decision_pattern_analysis_service.rb
@@ -10,12 +10,15 @@ class DecisionPatternAnalysisService
       .count
   end
 
-  def decision_count
+  def total_decisions
     decisions.count
   end
 
-  def most_category
-    category_counts.max_by { |_, count| count }
+  def decision_counts_by_month
+    decisions
+      .where.not(recorded_on: nil)
+      .group_by_month(:recorded_on, format: "%Y-%m")
+      .count
   end
 
   private

--- a/app/views/decision_pattern_analysis/index.html.erb
+++ b/app/views/decision_pattern_analysis/index.html.erb
@@ -4,7 +4,7 @@
     意思パターン分析
   </h1>
 
-  <% if @category_counts.present? %>
+  <% if @decision_count.present? && @decision_count > 0 %>
 
     <div class="row g-4 mb-4">
 
@@ -23,7 +23,6 @@
           </div>
         </div>
       </div>
-
 
       <div class="col-md-6">
         <div class="card shadow-sm border-0 rounded-3 h-100">
@@ -57,86 +56,104 @@
 
     </div>
 
-    <div class="card shadow-sm border-0 rounded-3 mb-4">
+    <% if @category_counts.present? %>
 
-      <div class="card-body p-4">
+      <div class="card shadow-sm border-0 rounded-3 mb-4">
 
-        <h2 class="h5 fw-bold mb-4">
-          カテゴリ別意思決定数
-        </h2>
+        <div class="card-body p-4">
 
+          <h2 class="h5 fw-bold mb-4">
+            カテゴリ別意思決定数
+          </h2>
 
-        <%= column_chart @category_counts,
-              height: "350px" %>
-
-
-      </div>
-
-    </div>
-
-    <div class="card shadow-sm border-0 rounded-3">
-
-      <div class="card-body p-4">
-
-        <h2 class="h5 fw-bold mb-4">
-          カテゴリ別集計
-        </h2>
-
-
-        <div class="table-responsive">
-
-          <table class="table table-striped mb-0">
-
-            <thead>
-              <tr>
-                <th>
-                  カテゴリ
-                </th>
-
-                <th class="text-end">
-                  件数
-                </th>
-              </tr>
-            </thead>
-
-
-            <tbody>
-
-              <% @category_counts.each do |category, count| %>
-
-                <tr>
-
-                  <td>
-                    <%= category %>
-                  </td>
-
-
-                  <td class="text-end">
-                    <%= count %>件
-                  </td>
-
-                </tr>
-
-              <% end %>
-
-            </tbody>
-
-          </table>
+          <%= column_chart @category_counts,
+                height: "350px" %>
 
         </div>
 
       </div>
 
+    <% end %>
+
+    <div class="card shadow-sm border-0 rounded-3 mb-4">
+
+      <div class="card-body p-4">
+
+        <h2 class="h5 fw-bold mb-4">
+          月別意思決定数
+        </h2>
+
+        <%= column_chart @decision_counts,
+              height: "350px" %>
+
+      </div>
+
     </div>
+
+    <% if @category_counts.present? %>
+
+      <div class="card shadow-sm border-0 rounded-3">
+
+        <div class="card-body p-4">
+
+          <h2 class="h5 fw-bold mb-4">
+            カテゴリ別集計
+          </h2>
+
+
+          <div class="table-responsive">
+
+            <table class="table table-striped mb-0">
+
+              <thead>
+                <tr>
+                  <th>
+                    カテゴリ
+                  </th>
+
+                  <th class="text-end">
+                    件数
+                  </th>
+                </tr>
+              </thead>
+
+              <tbody>
+
+                <% @category_counts.each do |category, count| %>
+
+                  <tr>
+
+                    <td>
+                      <%= category %>
+                    </td>
+
+
+                    <td class="text-end">
+                      <%= count %>件
+                    </td>
+
+                  </tr>
+
+                <% end %>
+
+              </tbody>
+
+            </table>
+
+          </div>
+
+        </div>
+
+      </div>
+
+    <% end %>
 
 
   <% else %>
 
-
     <div class="alert alert-info">
       意思決定データがありません。
     </div>
-
 
   <% end %>
 


### PR DESCRIPTION
## 概要
意思パターン分析に意思決定回数分析を追加

## 変更内容
- 意思決定の総数表示を追加
- 月別意思決定数の集計機能を追加
- 月別意思決定数のグラフ表示を追加
- カテゴリ分析と回数分析の表示条件を整理

## 確認方法
- localhost:3000 にアクセス
- 意思パターン分析ページを確認
- 総意思決定数、月別グラフが表示されることを確認

## 関連Issue
Closes #160 