### PR TITLE
分析UI作成

### DIFF
--- a/app/assets/stylesheets/decision_pattern_analysis.css
+++ b/app/assets/stylesheets/decision_pattern_analysis.css
@@ -1,0 +1,56 @@
+.decision-pattern-analysis {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.decision-pattern-analysis__title {
+  font-weight: 700;
+  margin-bottom: 2rem;
+}
+
+.decision-pattern-analysis__summary {
+  margin-bottom: 1.5rem;
+}
+
+.decision-pattern-analysis__card {
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.decision-pattern-analysis__summary-label {
+  color: #6c757d;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.decision-pattern-analysis__summary-value {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.decision-pattern-analysis__section-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+}
+
+.decision-pattern-analysis__table {
+  margin-bottom: 0;
+}
+
+.decision-pattern-analysis__table th {
+  font-weight: 600;
+  color: #495057;
+}
+
+.decision-pattern-analysis__table td,
+.decision-pattern-analysis__table th {
+  padding: 0.85rem 1rem;
+  vertical-align: middle;
+}
+
+.decision-pattern-analysis__chart {
+  min-height: 300px;
+}

--- a/app/views/decision_pattern_analysis/index.html.erb
+++ b/app/views/decision_pattern_analysis/index.html.erb
@@ -1,42 +1,42 @@
 <div class="decision-pattern-analysis">
 
-  <h1 class="mb-4">
+  <h1 class="decision-pattern-analysis__title">
     意思パターン分析
   </h1>
 
   <% if @decision_count.present? && @decision_count > 0 %>
 
-    <div class="row g-4 mb-4">
+    <div class="row g-4 decision-pattern-analysis__summary">
 
       <div class="col-md-6">
-        <div class="card shadow-sm border-0 rounded-3 h-100">
+        <div class="card decision-pattern-analysis__card h-100">
           <div class="card-body text-center py-4">
 
-            <p class="text-muted mb-2">
+            <div class="decision-pattern-analysis__summary-label">
               総意思決定数
-            </p>
+            </div>
 
-            <h2 class="fw-bold mb-0">
+            <p class="decision-pattern-analysis__summary-value">
               <%= @decision_count %>件
-            </h2>
+            </p>
 
           </div>
         </div>
       </div>
 
       <div class="col-md-6">
-        <div class="card shadow-sm border-0 rounded-3 h-100">
+        <div class="card decision-pattern-analysis__card h-100">
           <div class="card-body text-center py-4">
 
-            <p class="text-muted mb-2">
+            <div class="decision-pattern-analysis__summary-label">
               最も多いカテゴリ
-            </p>
+            </div>
 
             <% if @most_category.present? %>
 
-              <h2 class="fw-bold mb-1">
+              <p class="decision-pattern-analysis__summary-value">
                 <%= @most_category.first %>
-              </h2>
+              </p>
 
               <small class="text-muted">
                 <%= @most_category.last %>件
@@ -58,16 +58,18 @@
 
     <% if @category_counts.present? %>
 
-      <div class="card shadow-sm border-0 rounded-3 mb-4">
+      <div class="card decision-pattern-analysis__card mb-4">
 
         <div class="card-body p-4">
 
-          <h2 class="h5 fw-bold mb-4">
+          <h2 class="decision-pattern-analysis__section-title">
             カテゴリ別意思決定数
           </h2>
 
-          <%= column_chart @category_counts,
-                height: "350px" %>
+          <div class="decision-pattern-analysis__chart">
+            <%= column_chart @category_counts,
+                  height: "350px" %>
+          </div>
 
         </div>
 
@@ -75,16 +77,18 @@
 
     <% end %>
 
-    <div class="card shadow-sm border-0 rounded-3 mb-4">
+    <div class="card decision-pattern-analysis__card mb-4">
 
       <div class="card-body p-4">
 
-        <h2 class="h5 fw-bold mb-4">
+        <h2 class="decision-pattern-analysis__section-title">
           月別意思決定数
         </h2>
 
-        <%= column_chart @decision_counts,
-              height: "350px" %>
+        <div class="decision-pattern-analysis__chart">
+          <%= column_chart @decision_counts,
+                height: "350px" %>
+        </div>
 
       </div>
 
@@ -92,28 +96,22 @@
 
     <% if @category_counts.present? %>
 
-      <div class="card shadow-sm border-0 rounded-3">
+      <div class="card decision-pattern-analysis__card">
 
         <div class="card-body p-4">
 
-          <h2 class="h5 fw-bold mb-4">
+          <h2 class="decision-pattern-analysis__section-title">
             カテゴリ別集計
           </h2>
 
-
           <div class="table-responsive">
 
-            <table class="table table-striped mb-0">
+            <table class="table table-striped decision-pattern-analysis__table">
 
               <thead>
                 <tr>
-                  <th>
-                    カテゴリ
-                  </th>
-
-                  <th class="text-end">
-                    件数
-                  </th>
+                  <th>カテゴリ</th>
+                  <th class="text-end">件数</th>
                 </tr>
               </thead>
 
@@ -122,16 +120,13 @@
                 <% @category_counts.each do |category, count| %>
 
                   <tr>
-
                     <td>
                       <%= category %>
                     </td>
 
-
                     <td class="text-end">
                       <%= count %>件
                     </td>
-
                   </tr>
 
                 <% end %>


### PR DESCRIPTION
## 概要

意思パターン分析のUIを改善

## 変更内容

- 意思パターン分析ページのレイアウトを整理
- サマリーカードのデザインを統一
- グラフ表示部分のUIを改善
- カテゴリ別集計テーブルのデザインを整理
- 意思パターン分析専用CSSを追加

## 確認方法

- localhost:3000 にアクセス
- 意思パターン分析ページを開く
- サマリー、グラフ、カテゴリ別集計のUIを確認

## 関連Issue

Closes #161 