### PR TITLE
グラフ改善

### DIFF
--- a/app/views/decision_pattern_analysis/index.html.erb
+++ b/app/views/decision_pattern_analysis/index.html.erb
@@ -1,9 +1,5 @@
 <div class="decision-pattern-analysis">
 
-  <h1 class="decision-pattern-analysis__title">
-    意思パターン分析
-  </h1>
-
   <% if @decision_count.present? && @decision_count > 0 %>
 
     <div class="row g-4 decision-pattern-analysis__summary">
@@ -68,7 +64,19 @@
 
           <div class="decision-pattern-analysis__chart">
             <%= column_chart @category_counts,
-                  height: "350px" %>
+                  height: "350px",
+                  xtitle: "カテゴリ",
+                  ytitle: "意思決定数",
+                  library: {
+                    scales: {
+                      y: {
+                        beginAtZero: true,
+                        ticks: {
+                          precision: 0
+                        }
+                      }
+                    }
+                  } %>
           </div>
 
         </div>
@@ -87,7 +95,19 @@
 
         <div class="decision-pattern-analysis__chart">
           <%= column_chart @decision_counts,
-                height: "350px" %>
+                height: "350px",
+                xtitle: "月",
+                ytitle: "意思決定数",
+                library: {
+                  scales: {
+                    y: {
+                      beginAtZero: true,
+                      ticks: {
+                        precision: 0
+                      }
+                    }
+                  }
+                } %>
         </div>
 
       </div>
@@ -142,7 +162,6 @@
       </div>
 
     <% end %>
-
 
   <% else %>
 


### PR DESCRIPTION
## 概要

意思決定パターン分析のグラフを改善

## 変更内容

- カテゴリ別意思決定数グラフを改善
- 月別意思決定数グラフを改善
- グラフに軸ラベルを追加
- Y軸を0始まりに変更
- Y軸の数値を整数表示に統一

## 確認方法

- localhost:3000 にアクセス
- 意思パターン分析ページを開く
- カテゴリ別・月別のグラフを確認

## 関連Issue

Closes #162 