### PR TITLE
通知モデル作成

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,6 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+
+  validates :notification_type, presence: true
+  validates :title, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,5 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
   has_one_attached :avatar
   has_many :decisions, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 end

--- a/db/migrate/20260808140549_create_notifications.rb
+++ b/db/migrate/20260808140549_create_notifications.rb
@@ -1,0 +1,13 @@
+class CreateNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :notification_type
+      t.string :title
+      t.text :message
+      t.boolean :read
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_075133) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_08_140549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -78,6 +78,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_075133) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "message"
+    t.string "notification_type"
+    t.boolean "read"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "options", force: :cascade do |t|
     t.string "content"
     t.datetime "created_at", null: false
@@ -113,5 +124,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_075133) do
   add_foreign_key "decisions", "categories"
   add_foreign_key "decisions", "options", column: "selected_option_id", on_delete: :nullify
   add_foreign_key "decisions", "users"
+  add_foreign_key "notifications", "users"
   add_foreign_key "options", "decisions"
 end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  notification_type: MyString
+  title: MyString
+  message: MyText
+  read: false
+
+two:
+  user: two
+  notification_type: MyString
+  title: MyString
+  message: MyText
+  read: false

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

通知モデルを作成

## 変更内容

- Notificationモデルを追加
- notificationsテーブルを作成
- Userとの関連付けを追加
- 通知タイプ、タイトル、メッセージ、既読状態を管理できるように変更

## 確認方法

- `docker compose exec web bin/rails db:migrate` を実行
- Railsコンソールで `Notification.count` を実行
- エラーが発生しないことを確認

## 関連Issue

Closes #163 