### PR TITLE
メール通知機能

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,5 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start server via Thruster by default, this can be overwritten at runtime
 EXPOSE 80
-CMD ["./bin/thrust", "./bin/rails", "server"]
+#CMD ["./bin/thrust", "./bin/rails", "server"]
+CMD ["bin/start"]

--- a/app/controllers/notification_settings_controller.rb
+++ b/app/controllers/notification_settings_controller.rb
@@ -1,0 +1,27 @@
+class NotificationSettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+
+    if @user.update(notification_settings_params)
+      redirect_to notification_settings_path,
+                  notice: "通知設定を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def notification_settings_params
+    params.require(:user).permit(
+      :email_notification_enabled,
+      :email_notification_time
+    )
+  end
+end

--- a/app/helpers/notification_settings_helper.rb
+++ b/app/helpers/notification_settings_helper.rb
@@ -1,0 +1,2 @@
+module NotificationSettingsHelper
+end

--- a/app/jobs/email_notification_job.rb
+++ b/app/jobs/email_notification_job.rb
@@ -7,7 +7,10 @@ class EmailNotificationJob < ApplicationJob
     User.where(email_notification_enabled: true).find_each do |user|
       next unless user.email_notification_time.strftime("%H:%M") == current_time.strftime("%H:%M")
 
-      NotificationMailer.reminder(user).deliver_now
+      decision = user.decisions.order(created_at: :desc).first
+      next unless decision
+
+      NotificationMailer.reminder(user, decision).deliver_now
     end
   end
 end

--- a/app/jobs/email_notification_job.rb
+++ b/app/jobs/email_notification_job.rb
@@ -1,0 +1,13 @@
+class EmailNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    current_time = Time.current
+
+    User.where(email_notification_enabled: true).find_each do |user|
+      next unless user.email_notification_time.strftime("%H:%M") == current_time.strftime("%H:%M")
+
+      NotificationMailer.reminder(user).deliver_now
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "onboarding@resend.dev"
+
   layout "mailer"
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,10 +1,11 @@
 class NotificationMailer < ApplicationMailer
-  def reminder(user)
+  def reminder(user, decision)
     @user = user
+    @decision = decision
 
     mail(
       to: @user.email,
-      subject: "LifeBranchからのお知らせ"
+      subject: "最近の決断を振り返ってみませんか？"
     )
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,10 @@
+class NotificationMailer < ApplicationMailer
+  def reminder(user)
+    @user = user
+
+    mail(
+      to: @user.email,
+      subject: "LifeBranchからのお知らせ"
+    )
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -112,6 +112,10 @@
   <%= link_to "感情分析", emotion_analysis_path, class: "dropdown-item" %>
 </li>
 
+<li class="d-md-none">
+  <%= link_to "通知設定", notification_settings_path, class: "dropdown-item" %>
+</li>
+
   <li>
     <hr class="dropdown-divider">
   </li>
@@ -193,7 +197,10 @@
       class: "nav-link  w-100" %>
 
      <%= link_to "感情分析", emotion_analysis_path, class: "nav-link w-100" %>
-
+     <%= link_to "通知設定",
+          notification_settings_path,
+          class: "nav-link w-100",
+          data: { turbo: false } %>
             </ul>
 
           </aside>

--- a/app/views/notification_mailer/reminder.html.erb
+++ b/app/views/notification_mailer/reminder.html.erb
@@ -1,5 +1,26 @@
-<h1>LifeBranchからのお知らせ</h1>
+<h1>最近の決断を振り返ってみませんか？</h1>
 
-<p><%= @user.name %>さん</p>
+<p><%= @user.email %> さん</p>
 
-<p>LifeBranchからのお知らせです。</p>
+<p>LifeBranchに記録した最近の決断を振り返ってみましょう。</p>
+
+<h2><%= @decision.title %></h2>
+
+<p>
+  <strong>決断した日：</strong>
+  <%= @decision.created_at.strftime("%Y年%m月%d日") %>
+</p>
+
+<% if @decision.reason.present? %>
+  <p>
+    <strong>決断した理由：</strong><br>
+    <%= @decision.reason %>
+  </p>
+<% end %>
+
+<p>
+  あのとき、なぜこの決断をしたのか。
+  今の自分から振り返ってみませんか？
+</p>
+
+<p>LifeBranch</p>

--- a/app/views/notification_mailer/reminder.html.erb
+++ b/app/views/notification_mailer/reminder.html.erb
@@ -1,0 +1,5 @@
+<h1>LifeBranchからのお知らせ</h1>
+
+<p><%= @user.name %>さん</p>
+
+<p>LifeBranchからのお知らせです。</p>

--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -1,0 +1,31 @@
+<div class="max-w-2xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-6">通知設定</h1>
+
+  <%= form_with model: current_user,
+                url: notification_settings_path,
+                method: :patch do |form| %>
+
+    <div class="mb-6">
+      <%= form.label :email_notification_enabled,
+                     "メール通知",
+                     class: "block font-medium mb-2" %>
+
+      <div class="flex items-center gap-2">
+        <%= form.check_box :email_notification_enabled %>
+        <span>メール通知を受け取る</span>
+      </div>
+    </div>
+
+    <div class="mb-6">
+      <%= form.label :email_notification_time,
+                     "通知時刻",
+                     class: "block font-medium mb-2" %>
+
+      <%= form.time_field :email_notification_time,
+                          class: "border rounded px-3 py-2" %>
+    </div>
+
+    <%= form.submit "設定を保存",
+                    class: "px-4 py-2 rounded bg-blue-600 text-white" %>
+  <% end %>
+</div>

--- a/app/views/notification_settings/update.html.erb
+++ b/app/views/notification_settings/update.html.erb
@@ -1,0 +1,2 @@
+<h1>NotificationSettings#update</h1>
+<p>Find me in app/views/notification_settings/update.html.erb</p>

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+bin/jobs &
+exec rails server -b 0.0.0.0 -p "${PORT:-3000}"

--- a/bin/start
+++ b/bin/start
@@ -2,5 +2,8 @@
 
 set -e
 
+echo "===== STARTING SOLID QUEUE ====="
 bin/jobs &
+echo "===== SOLID QUEUE STARTED ====="
+
 exec rails server -b 0.0.0.0 -p "${PORT:-3000}"

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,6 @@ module LifeBranch
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+    config.time_zone = "Tokyo"
   end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -3,6 +3,10 @@ production:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
 
+  email_notification:
+    class: EmailNotificationJob
+    schedule: every minute
+
 development:
   solid_queue_test:
     class: SolidQueueTestJob

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,14 +1,3 @@
-# examples:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_cleanup_with_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
-
 production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
@@ -17,4 +6,8 @@ production:
 development:
   solid_queue_test:
     class: SolidQueueTestJob
+    schedule: every minute
+
+  email_notification:
+    class: EmailNotificationJob
     schedule: every minute

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,15 @@ Rails.application.routes.draw do
     end
   end
 
+  get "notification_settings",
+      to: "notification_settings#edit",
+      as: :notification_settings
+
+  patch "notification_settings",
+        to: "notification_settings#update"
+
   get "up" => "rails/health#show", as: :rails_health_check
+
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260809090813_add_email_notification_enabled_to_users.rb
+++ b/db/migrate/20260809090813_add_email_notification_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailNotificationEnabledToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :email_notification_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260809091242_add_email_notification_time_to_users.rb
+++ b/db/migrate/20260809091242_add_email_notification_time_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailNotificationTimeToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :email_notification_time, :time, default: "08:00", null: false
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_08_140549) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_091242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -224,6 +224,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_140549) do
     t.datetime "current_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
+    t.boolean "email_notification_enabled", default: true, null: false
+    t.time "email_notification_time", default: "2000-01-01 08:00:00", null: false
     t.string "encrypted_password", default: "", null: false
     t.boolean "first_login_done", default: false, null: false
     t.datetime "last_sign_in_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_08_140549) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_091242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -224,6 +224,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_140549) do
     t.datetime "current_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
+    t.boolean "email_notification_enabled", default: true, null: false
+    t.time "email_notification_time", default: "2000-01-01 08:00:00", null: false
     t.string "encrypted_password", default: "", null: false
     t.boolean "first_login_done", default: false, null: false
     t.datetime "last_sign_in_at"

--- a/test/controllers/notification_settings_controller_test.rb
+++ b/test/controllers/notification_settings_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class NotificationSettingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get edit" do
+    get notification_settings_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get notification_settings_update_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,8 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  email: test1@example.com
+
+two:
+  email: test2@example.com

--- a/test/jobs/email_notification_job_test.rb
+++ b/test/jobs/email_notification_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EmailNotificationJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class NotificationMailerTest < ActionMailer::TestCase
+  test "reminder" do
+    user = users(:one)
+
+    email = NotificationMailer.reminder(user)
+
+    assert_equal ["test1@example.com"], email.to
+    assert_equal ["from@example.com"], email.from
+    assert_equal "LifeBranchからのお知らせ", email.subject
+  end
+end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,3 @@
+# Preview all emails at http://localhost:3000/rails/mailers/notification_mailer
+class NotificationMailerPreview < ActionMailer::Preview
+end


### PR DESCRIPTION
## 概要

通知設定した時刻に、最近記録した決断を振り返るメール通知機能を実装

## 変更内容

- `EmailNotificationJob` を追加
- `NotificationMailer` を追加
- 通知設定した時刻にジョブを実行
- 最近記録した決断の内容をメール本文に表示
- Resendを利用してメールを送信
- Solid Queueで定期的にジョブを実行

## 確認方法

- 通知設定でメール通知をONにする
- 通知時刻を現在時刻の数分後に設定
- 設定時刻になるとメールが届くことを確認
- メール本文に最近記録した決断の内容が表示されることを確認

## 関連Issue

Closes #165 