### PR TITLE
通知設定UI

### DIFF
--- a/app/views/notification_settings/edit.html.erb
+++ b/app/views/notification_settings/edit.html.erb
@@ -1,31 +1,65 @@
-<div class="max-w-2xl mx-auto px-4 py-8">
-  <h1 class="text-2xl font-bold mb-6">通知設定</h1>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-10 col-lg-7">
 
-  <%= form_with model: current_user,
-                url: notification_settings_path,
-                method: :patch do |form| %>
+      <div class="card shadow-sm border-0">
+        <div class="card-body p-4 p-md-5">
 
-    <div class="mb-6">
-      <%= form.label :email_notification_enabled,
-                     "メール通知",
-                     class: "block font-medium mb-2" %>
+          <h1 class="h2 fw-bold mb-2">通知設定</h1>
 
-      <div class="flex items-center gap-2">
-        <%= form.check_box :email_notification_enabled %>
-        <span>メール通知を受け取る</span>
+          <p class="text-muted mb-5">
+            メール通知の設定を変更できます。
+          </p>
+
+          <%= form_with model: current_user,
+                        url: notification_settings_path,
+                        method: :patch do |form| %>
+
+            <div class="mb-5">
+              <%= form.label :email_notification_enabled,
+                             "メール通知",
+                             class: "form-label fs-5 fw-semibold" %>
+
+              <div class="form-check form-switch d-flex align-items-center gap-2">
+                <%= form.check_box :email_notification_enabled,
+                                   class: "form-check-input fs-4",
+                                   role: "switch",
+                                   id: "emailNotificationSwitch" %>
+
+                <%= form.label :email_notification_enabled,
+                               "メール通知を受け取る",
+                               class: "form-check-label fs-5",
+                               for: "emailNotificationSwitch" %>
+              </div>
+
+              <div class="form-text mt-2">
+                設定した時刻に最近記録した決断を振り返るメールを受け取ります。
+              </div>
+            </div>
+
+            <div class="mb-5">
+              <%= form.label :email_notification_time,
+                             "通知時刻",
+                             class: "form-label fs-5 fw-semibold" %>
+
+              <%= form.time_field :email_notification_time,
+                                  class: "form-control form-control-lg" %>
+
+              <div class="form-text mt-2">
+                毎日この時刻にメールが送信されます。
+              </div>
+            </div>
+
+            <div class="d-grid">
+              <%= form.submit "設定を保存",
+                              class: "btn btn-primary btn-lg" %>
+            </div>
+
+          <% end %>
+
+        </div>
       </div>
+
     </div>
-
-    <div class="mb-6">
-      <%= form.label :email_notification_time,
-                     "通知時刻",
-                     class: "block font-medium mb-2" %>
-
-      <%= form.time_field :email_notification_time,
-                          class: "border rounded px-3 py-2" %>
-    </div>
-
-    <%= form.submit "設定を保存",
-                    class: "px-4 py-2 rounded bg-blue-600 text-white" %>
-  <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## 概要

通知設定UIを作成

## 変更内容

- 通知設定画面を追加
- メール通知のON/OFF切り替えを追加
- 通知時刻の設定欄を追加
- BootstrapのSwitchを使用してUIを整備
- 通知設定の保存機能を追加

## 確認方法

- localhost:3000/notification_settings にアクセス
- メール通知のON/OFFを切り替えられることを確認
- 通知時刻を設定して保存できることを確認
- ページを再読み込みして設定が保持されていることを確認

## 関連Issue

Closes #166 