### PR TITLE
Googleログイン

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,9 @@ gem "groupdate"
 gem "pundit"
 
 gem "omniauth"
+
+gem "omniauth-google-oauth2"
+
+gem "omniauth-rails_csrf_protection"
+
+gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,11 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
+    anonymous_loader (0.1.3)
+      version_gem (~> 1.1, >= 1.1.14)
     ast (2.4.3)
+    auth-sanitizer (0.2.3)
+      version_gem (~> 1.1, >= 1.1.14)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
@@ -117,12 +121,21 @@ GEM
       responders
       warden (~> 1.2.3)
     dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.2)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     fugit (1.12.1)
@@ -160,6 +173,8 @@ GEM
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
+    jwt (3.2.0)
+      base64
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -208,6 +223,8 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.3)
       date
       net-protocol
@@ -227,11 +244,32 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    oauth2 (2.0.25)
+      anonymous_loader (~> 0.1, >= 0.1.3)
+      auth-sanitizer (~> 0.2, >= 0.2.3)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.7)
+      version_gem (~> 1.1, >= 1.1.14)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
       rack (>= 2.2.3)
       rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -361,6 +399,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.7)
+      hashie (>= 0.1.0, < 6)
+      version_gem (~> 1.1, >= 1.1.14)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -402,6 +443,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.15)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.3.0)
@@ -429,6 +471,7 @@ DEPENDENCIES
   chartkick
   debug
   devise (~> 5.0)
+  dotenv-rails
   groupdate
   image_processing (~> 1.2)
   importmap-rails
@@ -436,6 +479,8 @@ DEPENDENCIES
   kamal
   kaminari
   omniauth
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,14 @@
+class SessionsController < ApplicationController
+  def omniauth
+    auth = request.env["omniauth.auth"]
+
+    user = User.from_omniauth(auth)
+
+    sign_in user
+    redirect_to dashboard_path, notice: "Googleログインに成功しました。"
+  end
+
+  def failure
+    redirect_to root_path, alert: "Googleログインに失敗しました。"
+  end
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :trackable
@@ -10,7 +11,33 @@ class User < ApplicationRecord
   end
 
   validates :name, presence: true, length: { maximum: 50 }
+
   has_one_attached :avatar
   has_many :decisions, dependent: :destroy
   has_many :notifications, dependent: :destroy
+
+  def self.from_omniauth(auth)
+    user = find_by(provider: auth.provider, uid: auth.uid)
+
+    return user if user
+
+    user = find_by(email: auth.info.email)
+
+    if user
+      user.update!(
+        provider: auth.provider,
+        uid: auth.uid
+      )
+
+      return user
+    end
+
+    create!(
+      email: auth.info.email,
+      provider: auth.provider,
+      uid: auth.uid,
+      password: Devise.friendly_token[0, 20],
+      name: auth.info.name.presence || "Googleユーザー"
+    )
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -54,6 +54,16 @@
 
 <% end %>
 
+<!-- Google login -->
+
+<div class="d-grid mt-3">
+  <%= button_to "Googleでログイン",
+        "/auth/google_oauth2",
+        method: :post,
+        class: "btn btn-danger",
+        data: { turbo: false } %>
+</div>
+
 <!-- links -->
 <div class="mt-3 text-center">
   <%= render "devise/shared/links" %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,5 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2,
+           ENV["GOOGLE_CLIENT_ID"],
+           ENV["GOOGLE_CLIENT_SECRET"]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show", as: :rails_health_check
 
+  get "/auth/:provider/callback", to: "sessions#omniauth"
+  get "/auth/failure", to: "sessions#failure"
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260811121529_add_omniauth_to_users.rb
+++ b/db/migrate/20260811121529_add_omniauth_to_users.rb
@@ -1,0 +1,8 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+
+    add_index :users, [:provider, :uid], unique: true
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_091242) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_121529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -231,12 +231,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_091242) do
     t.datetime "last_sign_in_at"
     t.string "last_sign_in_ip"
     t.string "name"
+    t.string "provider"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.integer "sign_in_count"
+    t.string "uid"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_091242) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_121529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -231,12 +231,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_091242) do
     t.datetime "last_sign_in_at"
     t.string "last_sign_in_ip"
     t.string "name"
+    t.string "provider"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.integer "sign_in_count"
+    t.string "uid"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

Googleアカウントでログインできる機能を実装

## 変更内容

- OmniAuth Google OAuth2を導入
- Googleログインボタンを追加
- Google認証用のSessionsControllerを追加
- Googleアカウント情報からUserを作成・既存ユーザーと紐付け
- usersテーブルにproviderとuidを追加
- Googleログイン後にダッシュボードへリダイレクト

## 確認方法

- localhost:3000/users/sign_in にアクセス
- 「Googleでログイン」をクリック
- Googleアカウントで認証
- ダッシュボードへ遷移することを確認
- 初回ログイン時にUserが作成されることを確認

## 関連Issue

Closes #187 